### PR TITLE
version 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# version 1.3.1 2017-01-31
+- Fix bug when sqlQuote receives a stringable object but it does not take value to parse it as int or float
+
+# version 1.3.0  2016-11-14
+- Add Mssql driver
+- Allow pass entity and primary keys to Recordset
+- Sqlite uses fetch behavior to reset the query
+- Improve tests
+- Add Travis-CI support
+- Improve documentation
+
 # version 1.2.3 2016-09-01
 - Rename project to eclipxe/engineworks-dbal
 - Move from gitlab to github

--- a/sources/EngineWorks/DBAL/Traits/MethodSqlQuote.php
+++ b/sources/EngineWorks/DBAL/Traits/MethodSqlQuote.php
@@ -14,6 +14,9 @@ trait MethodSqlQuote
         if (! $asInteger && $isIntOrFloat) {
             return floatval($value);
         }
+        if (is_object($value)) {
+            $value = strval($value);
+        }
         if (! is_string($value)) {
             return 0;
         }

--- a/tests/EngineWorks/DBAL/Tests/Mssql/MssqlDbalDisconnectedTest.php
+++ b/tests/EngineWorks/DBAL/Tests/Mssql/MssqlDbalDisconnectedTest.php
@@ -91,6 +91,7 @@ class MssqlDbalDisconnectedTest extends TestCase
         $date = '2016-12-31';
         $time = '23:31:59';
         $datetime = "$date $time";
+        $xmlValue = (new \SimpleXMLElement('<' . 'd v="55.1"/>'))['v'];
         return [
             // texts
             'text normal' => ["'foo'", 'foo', DBAL::TTEXT, false],
@@ -144,6 +145,15 @@ class MssqlDbalDisconnectedTest extends TestCase
             // special chars
             "special char '" => ["''''", "'", DBAL::TTEXT, false],
             'special char \"' => ["'\"'", '"', DBAL::TTEXT, false],
+            //
+            // object
+            //
+            'object to string' => ["'55.1'", $xmlValue, DBAL::TTEXT, true],
+            'object to string not null' => ["'55.1'", $xmlValue, DBAL::TTEXT, false],
+            'object to int' => ["55", $xmlValue, DBAL::TINT, true],
+            'object to int not null' => ["55", $xmlValue, DBAL::TINT, false],
+            'object to number' => ["55.1", $xmlValue, DBAL::TNUMBER, true],
+            'object to number not null' => ["55.1", $xmlValue, DBAL::TNUMBER, false],
         ];
     }
 

--- a/tests/EngineWorks/DBAL/Tests/Sqlite/DBALDisconnectedTest.php
+++ b/tests/EngineWorks/DBAL/Tests/Sqlite/DBALDisconnectedTest.php
@@ -121,6 +121,7 @@ class DBALDisconnectedTest extends TestCase
         $date = '2016-12-31';
         $time = '23:31:59';
         $datetime = "$date $time";
+        $xmlValue = (new \SimpleXMLElement('<' . 'd v="55.1"/>'))['v'];
         return [
             // texts
             'text normal' => ["'foo'", 'foo', DBAL::TTEXT, false],
@@ -170,6 +171,15 @@ class DBALDisconnectedTest extends TestCase
             'null date notnull' => ["'1970-01-01'", null, DBAL::TDATE, false],
             'null time notnull' => ["'00:00:00'", null, DBAL::TTIME, false],
             'null datetime notnull' => ["'1970-01-01 00:00:00'", null, DBAL::TDATETIME, false],
+            //
+            // object
+            //
+            'object to string' => ["'55.1'", $xmlValue, DBAL::TTEXT, true],
+            'object to string not null' => ["'55.1'", $xmlValue, DBAL::TTEXT, false],
+            'object to int' => ["55", $xmlValue, DBAL::TINT, true],
+            'object to int not null' => ["55", $xmlValue, DBAL::TINT, false],
+            'object to number' => ["55.1", $xmlValue, DBAL::TNUMBER, true],
+            'object to number not null' => ["55.1", $xmlValue, DBAL::TNUMBER, false],
         ];
     }
 


### PR DESCRIPTION
Fix sqlQuote(object, CommonTypes::TINT) always return 0 This also includes new cases on tests to probe previous fix