### PR TITLE
Version 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# version 1.4.1 2017-02-23
+- There were some errors using the recordset on weird table and field names, this version make the following changes:
+    - `sqlField(a, b) => a as "b"`: New method, only escape the alias
+    - `sqlFieldEscape(a, b) => "a" as "b"`: New method, escape both, the name and the alias
+    - `sqlTable(a, b) => "suffix_a" as "b"`: Not changed
+    - `sqlTableEscape(a, b) => "a" as "b"`: Changed from protected to public
+- Change Recordset to use this methods when building the sql sentences.
+
 # version 1.3.1 2017-01-31
 - Fix bug when sqlQuote receives a stringable object but it does not take value to parse it as int or float
 

--- a/sources/EngineWorks/DBAL/DBAL.php
+++ b/sources/EngineWorks/DBAL/DBAL.php
@@ -105,8 +105,9 @@ abstract class DBAL implements CommonTypes, LoggerAwareInterface
     abstract public function transRollback();
 
     /**
-     * Escapes a table name and optionally renames it
-     * This function use the prefix setting
+     * Escapes a table name including its prefix and optionally renames it.
+     * This is the same method as sqlTableEscape but using the table prefix from settings.
+     * Optionaly renames it as an alias.
      *
      * @param string $tableName
      * @param string $asTable
@@ -116,6 +117,43 @@ abstract class DBAL implements CommonTypes, LoggerAwareInterface
     {
         return $this->sqlTableEscape($this->settings->get('prefix', '') . $tableName, $asTable);
     }
+
+    /**
+     * Escapes a table name to not get confused with reserved words or invalid chars.
+     * Optionaly renames it as an alias.
+     *
+     * @param string $tableName
+     * @param string $asTable
+     * @return string
+     */
+    abstract public function sqlTableEscape($tableName, $asTable = '');
+
+    /**
+     * Return a field name
+     * Optionaly renames it as an alias.
+     * This function do not escape the field name.
+     *
+     * Use example: $dbal->sqlField('COUNT(*)', 'rows'); or $dbal->sqlField('name')
+     *
+     * @see self::sqlFieldEscape
+     * @param string $fieldName
+     * @param string $asFieldName
+     * @return mixed
+     */
+    final public function sqlField($fieldName, $asFieldName = '')
+    {
+        return $fieldName . (('' !== $asFieldName) ? ' AS ' . $this->sqlFieldEscape($asFieldName) : '');
+    }
+
+    /**
+     * Escapes a table name to not get confused with reserved words or invalid chars.
+     * Optionaly renames it as an alias.
+     *
+     * @param string $tableName
+     * @param string $asTable
+     * @return string
+     */
+    abstract public function sqlFieldEscape($tableName, $asTable = '');
 
     /**
      * Parses a value to secure SQL
@@ -249,14 +287,6 @@ abstract class DBAL implements CommonTypes, LoggerAwareInterface
     /* -----
      * protected methods (to override)
      */
-
-    /**
-     * Function to escape a table name to not get confused with functions or so
-     * @param string $tableName
-     * @param string $asTable
-     * @return string
-     */
-    abstract protected function sqlTableEscape($tableName, $asTable);
 
     /**
      * Executes a query and return a Result

--- a/sources/EngineWorks/DBAL/Mssql/DBAL.php
+++ b/sources/EngineWorks/DBAL/Mssql/DBAL.php
@@ -167,9 +167,14 @@ class DBAL extends AbstractDBAL
         return 'Cannot get the error because there are no active connection';
     }
 
-    protected function sqlTableEscape($tableName, $asTable)
+    public function sqlTableEscape($tableName, $asTable = '')
     {
-        return '[' . $tableName . ']' . (($asTable) ? ' AS ' . $asTable : '');
+        return '[' . $tableName . ']' . (('' !== $asTable) ? ' AS [' . $asTable . ']' : '');
+    }
+
+    public function sqlFieldEscape($fieldName, $asFieldName = '')
+    {
+        return '[' . $fieldName . ']' . (('' !== $asFieldName) ? ' AS [' . $asFieldName . ']' : '');
     }
 
     public function sqlDatePart($part, $expression)

--- a/sources/EngineWorks/DBAL/Mysqli/DBAL.php
+++ b/sources/EngineWorks/DBAL/Mysqli/DBAL.php
@@ -152,9 +152,14 @@ class DBAL extends AbstractDBAL
         return 'Cannot get the error because there are no active connection';
     }
 
-    protected function sqlTableEscape($tableName, $asTable)
+    public function sqlTableEscape($tableName, $asTable = '')
     {
-        return chr(96) . $tableName . chr(96) . (($asTable) ? ' AS ' . $asTable : '');
+        return '`' . $tableName . '`' . (('' !== $asTable) ? ' AS `' . $asTable . '`' : '');
+    }
+
+    public function sqlFieldEscape($fieldName, $asFieldName = '')
+    {
+        return '`' . $fieldName . '`' . (('' !== $asFieldName) ? ' AS `' . $asFieldName . '`' : '');
     }
 
     public function sqlDatePart($part, $expression)

--- a/sources/EngineWorks/DBAL/Sqlite/DBAL.php
+++ b/sources/EngineWorks/DBAL/Sqlite/DBAL.php
@@ -101,9 +101,14 @@ class DBAL extends AbstractDBAL
         return 'Cannot get the error because there are no active connection';
     }
 
-    protected function sqlTableEscape($tableName, $asTable)
+    public function sqlTableEscape($tableName, $asTable = '')
     {
-        return '"' . $tableName . '"' . (($asTable) ? ' AS ' . '"' . $asTable . '"' : '');
+        return '"' . $tableName . '"' . (('' !== $asTable) ? ' AS ' . '"' . $asTable . '"' : '');
+    }
+
+    public function sqlFieldEscape($fieldName, $asFieldName = '')
+    {
+        return '"' . $fieldName . '"' . (('' !== $asFieldName) ? ' AS ' . '"' . $asFieldName . '"' : '');
     }
 
     public function sqlConcatenate(...$strings)

--- a/tests/EngineWorks/DBAL/Tests/Sqlite/DBALDisconnectedTest.php
+++ b/tests/EngineWorks/DBAL/Tests/Sqlite/DBALDisconnectedTest.php
@@ -104,15 +104,30 @@ class DBALDisconnectedTest extends TestCase
      * sql tests
      *
      */
+
+    public function testSqlField()
+    {
+        $dbal = $this->factory->dbal($this->factory->settings([]));
+        $expectedName = 'some-field AS "some - label"';
+        $this->assertSame($expectedName, $dbal->sqlField('some-field', 'some - label'));
+    }
+
+    public function testSqlFieldEscape()
+    {
+        $dbal = $this->factory->dbal($this->factory->settings([]));
+        $expectedName = '"some-field" AS "some - label"';
+        $this->assertSame($expectedName, $dbal->sqlFieldEscape('some-field', 'some - label'));
+    }
+
     public function testSqlTable()
     {
         $dbal = $this->factory->dbal($this->factory->settings([
-            'filename' => 'non-existent',
             'prefix' => 'foo_',
-
         ]));
         $expectedName = '"foo_bar" AS "x"';
         $this->assertSame($expectedName, $dbal->sqlTable('bar', 'x'));
+        $expectedNoSuffix = '"bar" AS "x"';
+        $this->assertSame($expectedNoSuffix, $dbal->sqlTableEscape('bar', 'x'));
     }
 
     public function providerSqlQuote()


### PR DESCRIPTION
- There were some errors using the recordset on weird table and field names, this version make the following changes:
    - `sqlField(a, b) => a as "b"`: New method, only escape the alias
    - `sqlFieldEscape(a, b) => "a" as "b"`: New method, escape both, the name and the alias
    - `sqlTable(a, b) => "suffix_a" as "b"`: Not changed
    - `sqlTableEscape(a, b) => "a" as "b"`: Changed from protected to public
- Change Recordset to use this methods when building the sql sentences.
