### PR TITLE
version 1.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-# version 1.6.3 2017-03-23
+# version 1.6.4 2017-05-04
+- Trigger a E_USER_NOTICE when rollback or commit without a transaction
+- Create TransactionsWithExceptionsTestTrait to probe previous behavior,
+  the testers cannot test exceptions since all the execution runs as only one test. 
+
+# version 1.6.3 2017-03-31
 - Remove autocommit disabled. If it is disabled dbal will not store data unless is inside a transaction.
 
 # version 1.6.2 2017-03-23

--- a/TODO.md
+++ b/TODO.md
@@ -7,6 +7,7 @@
 - Create ReadOnlyRecordSet as a light object
 - Evolve Pager to stop using Recordset and depends on Result or another light object
 - Test with more than 96% coverage
+- DBAL::sqlQuote could be a final public method
 
 ## Known problems
 

--- a/sources/EngineWorks/DBAL/DBAL.php
+++ b/sources/EngineWorks/DBAL/DBAL.php
@@ -180,7 +180,7 @@ abstract class DBAL implements CommonTypes, LoggerAwareInterface
         $this->logger->info('-- TRANSACTION COMMIT');
         // reduce the transaction level
         if ($this->transactionLevel === 0) {
-            trigger_error("Try to call commit without a transaction", E_USER_NOTICE);
+            trigger_error('Try to call commit without a transaction', E_USER_NOTICE);
             return;
         }
         $this->transactionLevel = $this->transactionLevel - 1;
@@ -200,7 +200,7 @@ abstract class DBAL implements CommonTypes, LoggerAwareInterface
         $this->logger->info('-- TRANSACTION ROLLBACK ');
         // reduce the transaction level
         if ($this->transactionLevel === 0) {
-            trigger_error("Try to call rollback without a transaction", E_USER_NOTICE);
+            trigger_error('Try to call rollback without a transaction', E_USER_NOTICE);
             return;
         }
         $this->transactionLevel = $this->transactionLevel - 1;

--- a/sources/EngineWorks/DBAL/DBAL.php
+++ b/sources/EngineWorks/DBAL/DBAL.php
@@ -179,6 +179,10 @@ abstract class DBAL implements CommonTypes, LoggerAwareInterface
     {
         $this->logger->info('-- TRANSACTION COMMIT');
         // reduce the transaction level
+        if ($this->transactionLevel === 0) {
+            trigger_error("Try to call commit without a transaction", E_USER_NOTICE);
+            return;
+        }
         $this->transactionLevel = $this->transactionLevel - 1;
         // do commit or savepoint
         if (0 === $this->transactionLevel) {
@@ -195,6 +199,10 @@ abstract class DBAL implements CommonTypes, LoggerAwareInterface
     {
         $this->logger->info('-- TRANSACTION ROLLBACK ');
         // reduce the transaction level
+        if ($this->transactionLevel === 0) {
+            trigger_error("Try to call rollback without a transaction", E_USER_NOTICE);
+            return;
+        }
         $this->transactionLevel = $this->transactionLevel - 1;
         // do rollback or savepoint
         if (0 === $this->transactionLevel) {

--- a/tests/EngineWorks/DBAL/Tests/Mssql/MssqlDbalConnectedTest.php
+++ b/tests/EngineWorks/DBAL/Tests/Mssql/MssqlDbalConnectedTest.php
@@ -6,9 +6,13 @@ use EngineWorks\DBAL\Result;
 use EngineWorks\DBAL\Tests\RecordsetTester;
 use EngineWorks\DBAL\Tests\TestCaseWithMssqlDatabase;
 use EngineWorks\DBAL\Tests\TransactionsTester;
+use EngineWorks\DBAL\Tests\TransactionsWithExceptionsTestTrait;
 
 class MssqlDbalConnectedTest extends TestCaseWithMssqlDatabase
 {
+    // composite with transactions trait
+    use TransactionsWithExceptionsTestTrait;
+
     public function testConnectAndDisconnect()
     {
         $this->dbal->disconnect();

--- a/tests/EngineWorks/DBAL/Tests/Mysqli/MysqliDbalConnectedTest.php
+++ b/tests/EngineWorks/DBAL/Tests/Mysqli/MysqliDbalConnectedTest.php
@@ -6,9 +6,13 @@ use EngineWorks\DBAL\Result;
 use EngineWorks\DBAL\Tests\RecordsetTester;
 use EngineWorks\DBAL\Tests\TestCaseWithMysqliDatabase;
 use EngineWorks\DBAL\Tests\TransactionsTester;
+use EngineWorks\DBAL\Tests\TransactionsWithExceptionsTestTrait;
 
 class MysqliDbalConnectedTest extends TestCaseWithMysqliDatabase
 {
+    // composite with transactions trait
+    use TransactionsWithExceptionsTestTrait;
+
     public function testConnectAndDisconnect()
     {
         $this->dbal->disconnect();

--- a/tests/EngineWorks/DBAL/Tests/Sqlite/SqliteConnectedTest.php
+++ b/tests/EngineWorks/DBAL/Tests/Sqlite/SqliteConnectedTest.php
@@ -6,9 +6,13 @@ use EngineWorks\DBAL\Result;
 use EngineWorks\DBAL\Tests\RecordsetTester;
 use EngineWorks\DBAL\Tests\TestCaseWithSqliteDatabase;
 use EngineWorks\DBAL\Tests\TransactionsTester;
+use EngineWorks\DBAL\Tests\TransactionsWithExceptionsTestTrait;
 
 class SqliteConnectedTest extends TestCaseWithSqliteDatabase
 {
+    // composite with transactions trait
+    use TransactionsWithExceptionsTestTrait;
+
     public function testConnectAndDisconnect()
     {
         $this->dbal->disconnect();

--- a/tests/EngineWorks/DBAL/Tests/TestCaseWithDatabase.php
+++ b/tests/EngineWorks/DBAL/Tests/TestCaseWithDatabase.php
@@ -168,4 +168,9 @@ abstract class TestCaseWithDatabase extends TestCase
             $this->assertNotSame(false, $execute, "Fail to run $statement");
         }
     }
+
+    protected function getDbal()
+    {
+        return $this->dbal;
+    }
 }

--- a/tests/EngineWorks/DBAL/Tests/TransactionsWithExceptionsTestTrait.php
+++ b/tests/EngineWorks/DBAL/Tests/TransactionsWithExceptionsTestTrait.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\Error\Notice;
 trait TransactionsWithExceptionsTestTrait
 {
     /** @return DBAL */
-    protected abstract function getDbal();
+    abstract protected function getDbal();
 
     public function testCommitThrowsWarningWithOutBegin()
     {

--- a/tests/EngineWorks/DBAL/Tests/TransactionsWithExceptionsTestTrait.php
+++ b/tests/EngineWorks/DBAL/Tests/TransactionsWithExceptionsTestTrait.php
@@ -13,12 +13,18 @@ trait TransactionsWithExceptionsTestTrait
 
     public function testCommitThrowsWarningWithOutBegin()
     {
+        if (version_compare(PHP_VERSION, '7.0', '<')) {
+            $this->markTestSkipped('This test only runs on php 7.0 or higher');
+        }
         $this->expectException(Notice::class);
         $this->getDbal()->transCommit();
     }
 
     public function testRollbackThrowsWarningWithOutBegin()
     {
+        if (version_compare(PHP_VERSION, '7.0', '<')) {
+            $this->markTestSkipped('This test only runs on php 7.0 or higher');
+        }
         $this->expectException(Notice::class);
         $this->getDbal()->transRollback();
     }

--- a/tests/EngineWorks/DBAL/Tests/TransactionsWithExceptionsTestTrait.php
+++ b/tests/EngineWorks/DBAL/Tests/TransactionsWithExceptionsTestTrait.php
@@ -1,0 +1,25 @@
+<?php
+namespace EngineWorks\DBAL\Tests;
+
+use EngineWorks\DBAL\DBAL;
+use PHPUnit\Framework\Error\Notice;
+
+/* @var $this \EngineWorks\DBAL\Tests\TestCaseWithDatabase */
+
+trait TransactionsWithExceptionsTestTrait
+{
+    /** @return DBAL */
+    protected abstract function getDbal();
+
+    public function testCommitThrowsWarningWithOutBegin()
+    {
+        $this->expectException(Notice::class);
+        $this->getDbal()->transCommit();
+    }
+
+    public function testRollbackThrowsWarningWithOutBegin()
+    {
+        $this->expectException(Notice::class);
+        $this->getDbal()->transRollback();
+    }
+}


### PR DESCRIPTION
- Trigger a E_USER_NOTICE when rollback or commit without a transaction
- Create TransactionsWithExceptionsTestTrait to probe previous behavior,
  the testers cannot test exceptions since all the execution runs as only one test. 