### PR TITLE
Version 1.6.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# version 1.6.6 2017-06-26
+- Override docblock Result::getIterator() extended from \IteratorAggregate to explicity return an \Iterator object
+- Override docblock count extended from \Countable for coherence
+
 # version 1.6.5 2017-06-26
 - Fix typo in docblock, class name is ResultIterator
 - Fix docblock ResultImplementsIterator::getIterator() : \Iterator

--- a/sources/EngineWorks/DBAL/Result.php
+++ b/sources/EngineWorks/DBAL/Result.php
@@ -45,4 +45,16 @@ interface Result extends \IteratorAggregate, \Countable
      * @return bool
      */
     public function moveTo($offset);
+
+    /**
+     * Retrieve an iterator
+     * @return \Iterator
+     */
+    public function getIterator();
+
+    /**
+     * Return the total recprds of the resultset
+     * @return int
+     */
+    public function count();
 }


### PR DESCRIPTION
- Override docblock Result::getIterator() extended from \IteratorAggregate to explicity return an \Iterator object
- Override docblock count extended from \Countable for coherence