### PR TITLE
Version 2.3.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
           --health-retries 3
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0']
+        php-versions: ['7.3', '7.4', '8.0', '8.1']
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="phpcs" version="^3.6.1" installed="3.6.1" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.6.1" installed="3.6.1" location="./tools/phpcbf" copy="false"/>
-  <phar name="php-cs-fixer" version="^3.3.2" installed="3.3.2" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpstan" version="^1.2.0" installed="1.2.0" location="./tools/phpstan" copy="false"/>
+  <phar name="phpcs" version="^3.6.1" installed="3.6.2" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^3.6.1" installed="3.6.2" location="./tools/phpcbf" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.8.0" installed="3.8.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpstan" version="^1.5.4" installed="1.5.4" location="./tools/phpstan" copy="false"/>
 </phive>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 - See [Version 3](VERSION_3.md) for major changes
 
+# Version 2.3.1 2022-04-04
+
+- Fix bug when escaping chars on method `Mssql\DBAL::sqlLike()` and `Sqlsrv\DBAL::sqlLike()`.
+- Update license year to 2022. Happy new year on April.
+- Add PHP 8.1 to test matrix.
+- Upgrade development tools and issues found.
+
+
 # Version 2.3.0 2021-06-14
 
 Notice: If you are just using this library then it does not introduce any breaking change.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2013 - 2021 Carlos C Soto
+Copyright (c) 2013 - 2022 Carlos C Soto
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Iterators/RecordsetIterator.php
+++ b/src/Iterators/RecordsetIterator.php
@@ -38,9 +38,8 @@ class RecordsetIterator implements Iterator
         $this->keySeparator = $keySeparator;
     }
 
-    /**
-     * @return array<string, mixed>
-     */
+    /** @return array<string, scalar|null> */
+    #[\ReturnTypeWillChange]
     public function current(): array
     {
         return $this->recordset->values;
@@ -58,6 +57,7 @@ class RecordsetIterator implements Iterator
      *
      * @return int|string
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         if (! count($this->keyFields)) {

--- a/src/Iterators/ResultIterator.php
+++ b/src/Iterators/ResultIterator.php
@@ -31,11 +31,13 @@ class ResultIterator implements Iterator
     }
 
     /** @return array<string, scalar|null>|false */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->currentValues;
     }
 
+    #[\ReturnTypeWillChange]
     public function key(): int
     {
         return $this->index;

--- a/src/Mssql/DBAL.php
+++ b/src/Mssql/DBAL.php
@@ -237,7 +237,7 @@ class DBAL extends BaseDBAL
     ): string {
         $searchString = str_replace(
             ['[', '_', '%'],
-            ['[[]' . '[_]', '[%]'],
+            ['[[]', '[_]', '[%]'],
             $searchString
         );
         return $fieldName . " LIKE '"

--- a/src/Mysqli/DBAL.php
+++ b/src/Mysqli/DBAL.php
@@ -13,6 +13,7 @@ use EngineWorks\DBAL\Traits\MethodSqlLimit;
 use InvalidArgumentException;
 use LogicException;
 use mysqli;
+use mysqli_driver;
 use mysqli_result;
 use RuntimeException;
 
@@ -40,7 +41,11 @@ class DBAL extends BaseDBAL
         $errorLevel = error_reporting(0);
         $mysqli = mysqli_init();
         if (! $mysqli instanceof mysqli) {
+            error_reporting($errorLevel);
             throw new LogicException('Unable to create Mysqli empty object');
+        }
+        if (MYSQLI_REPORT_OFF !== (new mysqli_driver())->report_mode) {
+            throw new RuntimeException('Mysqli error report mode should be MYSQLI_REPORT_OFF');
         }
         $this->mysqli = $mysqli;
         $connectTimeout = $this->settings->get('connect-timeout');
@@ -145,7 +150,7 @@ class DBAL extends BaseDBAL
     protected function queryAffectedRows(string $query)
     {
         if (false !== $this->queryDriver($query)) {
-            return max(0, $this->mysqli()->affected_rows);
+            return max(0, (int) $this->mysqli()->affected_rows);
         }
         return false;
     }

--- a/src/Mysqli/Result.php
+++ b/src/Mysqli/Result.php
@@ -159,7 +159,7 @@ class Result implements ResultInterface
 
     public function resultCount(): int
     {
-        return $this->query->num_rows;
+        return (int) $this->query->num_rows;
     }
 
     public function fetchRow()

--- a/src/Sqlsrv/DBAL.php
+++ b/src/Sqlsrv/DBAL.php
@@ -251,7 +251,7 @@ class DBAL extends BaseDBAL
     ): string {
         $searchString = str_replace(
             ['[', '_', '%'],
-            ['[[]' . '[_]', '[%]'],
+            ['[[]', '[_]', '[%]'],
             $searchString
         );
         return $fieldName . " LIKE '"

--- a/src/Sqlsrv/Result.php
+++ b/src/Sqlsrv/Result.php
@@ -77,6 +77,7 @@ class Result implements ResultInterface
      */
     public function __construct(PDOStatement $result, array $overrideTypes = [])
     {
+        /** @phpstan-var int<-1, max> $numRows Sqlsrv returns -1 */
         $numRows = $result->rowCount();
         if (-1 === $numRows) {
             throw new RuntimeException('Must use cursor PDO::CURSOR_SCROLL');

--- a/tests/Tests/DBAL/Mysqli/MysqliDbalConnectedTest.php
+++ b/tests/Tests/DBAL/Mysqli/MysqliDbalConnectedTest.php
@@ -56,7 +56,7 @@ class MysqliDbalConnectedTest extends MysqliWithDatabaseTestCase
         $sql = 'SELECT * FROM albums WHERE (albumid = 1);';
         $recordset = $this->createRecordset($sql);
         $recordset->values['isfree'] = (int) $recordset->values['isfree'];
-        $recordset->values['collect'] = $recordset->values['collect'] + 0.00001;
+        $recordset->values['collect'] = (float) $recordset->values['collect'] + 0.00001;
         $this->assertTrue($recordset->valuesHadChanged());
         $update = $recordset->update();
 

--- a/tests/Tests/DBAL/TesterTraits/DbalQueriesTrait.php
+++ b/tests/Tests/DBAL/TesterTraits/DbalQueriesTrait.php
@@ -304,7 +304,6 @@ trait DbalQueriesTrait
     {
         $expectedTablename = $this->overrideEntity();
         $sql = 'SELECT * FROM albums WHERE (albumid = 5);';
-        /** @var Result $result */
         $result = $this->queryResult($sql, $this->overrideTypes());
         $this->assertInstanceOf(Result::class, $result);
         $this->assertSame(1, $result->resultCount());
@@ -398,7 +397,6 @@ trait DbalQueriesTrait
     {
         $dbal = $this->getDbal();
         $this->expectDeprecation();
-        /** @noinspection PhpDeprecationInspection */
         $dbal->query('SELECT 1');
     }
 }

--- a/tests/Tests/MysqliWithDatabaseTestCase.php
+++ b/tests/Tests/MysqliWithDatabaseTestCase.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace EngineWorks\DBAL\Tests;
 
+use mysqli_driver;
+
 class MysqliWithDatabaseTestCase extends WithDatabaseTestCase
 {
     protected function checkIsAvailable(): void
@@ -13,6 +15,11 @@ class MysqliWithDatabaseTestCase extends WithDatabaseTestCase
         }
         if (! function_exists('mysqli_init')) {
             $this->markTestSkipped('Environment does not have the extension mysqli');
+        }
+        if (MYSQLI_REPORT_OFF !== (new mysqli_driver())->report_mode) {
+            if (! mysqli_report(MYSQLI_REPORT_OFF)) {
+                $this->markTestSkipped('Cannot set Mysqli error report mode to MYSQLI_REPORT_OFF');
+            }
         }
     }
 

--- a/tests/Tests/WithDatabaseTestCase.php
+++ b/tests/Tests/WithDatabaseTestCase.php
@@ -186,10 +186,10 @@ abstract class WithDatabaseTestCase extends WithDbalTestCase
         for ($i = 11; $i <= 45; $i++) {
             $data[] = [
                 $i,
-                $faker->name,
+                $faker->name(),
                 $faker->numberBetween(0, 20),
                 $faker->numberBetween(strtotime('2016-01-01'), strtotime('2017-01-01') - 1),
-                $faker->boolean,
+                $faker->boolean(),
                 round($faker->numberBetween(0, 99999999) / 100, 2),
             ];
         }


### PR DESCRIPTION
- Fix bug when escaping chars on method `Mssql\DBAL::sqlLike()` and `Sqlsrv\DBAL::sqlLike()`.
- Update license year to 2022. Happy new year on April.
- Add PHP 8.1 to test matrix.
- Upgrade development tools and issues found.
