### PR TITLE
Version 2.3.2

### DIFF
--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="phpcs" version="^3.6.1" installed="3.6.2" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.6.1" installed="3.6.2" location="./tools/phpcbf" copy="false"/>
+  <phar name="phpcs" version="^3.6.2" installed="3.6.2" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^3.6.2" installed="3.6.2" location="./tools/phpcbf" copy="false"/>
   <phar name="php-cs-fixer" version="^3.8.0" installed="3.8.0" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpstan" version="^1.5.4" installed="1.5.4" location="./tools/phpstan" copy="false"/>
+  <phar name="phpstan" version="^1.6.7" installed="1.6.7" location="./tools/phpstan" copy="false"/>
 </phive>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 - See [Version 3](VERSION_3.md) for major changes
 
+# Version 2.3.2 2022-05-05
+
+- Improve typing on `Recordset` and `RecordsetIterator`.
+- Improve comparison to check for empty arrays, avoid `count`.
+- Refactor and improve logic for `Result::getFields()`.
+
 # Version 2.3.1 2022-04-04
 
 - Fix bug when escaping chars on method `Mssql\DBAL::sqlLike()` and `Sqlsrv\DBAL::sqlLike()`.

--- a/src/Abstracts/BaseDBAL.php
+++ b/src/Abstracts/BaseDBAL.php
@@ -246,7 +246,7 @@ abstract class BaseDBAL implements DBAL
         string $commonType = CommonTypes::TTEXT,
         bool $includeNull = false
     ): string {
-        if (0 === count($values)) {
+        if ([] === $values) {
             throw new RuntimeException('The array of values passed to DBAL::sqlQuoteIn is empty');
         }
         return '('
@@ -270,7 +270,7 @@ abstract class BaseDBAL implements DBAL
             );
             return $this->sqlNotIn($field, $values, $commonType, $includeNull);
         }
-        if (0 === count($values)) {
+        if ([] === $values) {
             return '0 = 1';
         }
         return $field . ' IN ' . $this->sqlQuoteIn($values, $commonType, $includeNull);
@@ -282,7 +282,7 @@ abstract class BaseDBAL implements DBAL
         string $commonType = CommonTypes::TTEXT,
         bool $includeNull = false
     ): string {
-        if (0 === count($values)) {
+        if ([] === $values) {
             return '1 = 1';
         }
         return $field . ' NOT IN ' . $this->sqlQuoteIn($values, $commonType, $includeNull);

--- a/src/Internal/SqlServerResultFields.php
+++ b/src/Internal/SqlServerResultFields.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EngineWorks\DBAL\Internal;
+
+use EngineWorks\DBAL\CommonTypes;
+use PDOStatement;
+
+final class SqlServerResultFields
+{
+    private const TYPES = [
+        // integers
+        'int' => CommonTypes::TINT,
+        'tinyint' => CommonTypes::TINT,
+        'smallint' => CommonTypes::TINT,
+        'bigint' => CommonTypes::TINT,
+        // floats
+        'float' => CommonTypes::TNUMBER,
+        'real' => CommonTypes::TNUMBER,
+        'decimal' => CommonTypes::TNUMBER,
+        'numeric' => CommonTypes::TNUMBER,
+        'money' => CommonTypes::TNUMBER,
+        'smallmoney' => CommonTypes::TNUMBER,
+        // dates
+        'date' => CommonTypes::TDATE,
+        'time' => CommonTypes::TTIME,
+        'datetime' => CommonTypes::TDATETIME,
+        'smalldatetime' => CommonTypes::TDATETIME,
+        // bool
+        'bit' => CommonTypes::TBOOL,
+        // text
+        'char' => CommonTypes::TTEXT,
+        'varchar' => CommonTypes::TTEXT,
+        'text' => CommonTypes::TTEXT,
+    ];
+
+    /** @var array<string, string> */
+    private $overrideTypes;
+
+    /** @var string */
+    private $nativeTypeKey;
+
+    /** @param array<string, string> $overrideTypes */
+    public function __construct(array $overrideTypes, string $nativeTypeKey)
+    {
+        $this->overrideTypes = $overrideTypes;
+        $this->nativeTypeKey = $nativeTypeKey;
+    }
+
+    /** @return array<int, array{name: string, table: string, commontype: string}> */
+    public function obtainFields(PDOStatement $statement): array
+    {
+        $columnsCount = $statement->columnCount();
+        $columns = [];
+        for ($column = 0; $column < $columnsCount; $column++) {
+            $columnMeta = $statement->getColumnMeta($column);
+            if (is_array($columnMeta)) {
+                $columns[] = $columnMeta;
+            }
+        }
+        $fields = [];
+        foreach ($columns as $fetched) {
+            $fields[] = [
+                'name' => $fetched['name'],
+                'commontype' => $this->getCommonType($fetched['name'], $fetched[$this->nativeTypeKey]),
+                'table' => $fetched['table'] ?? '',
+            ];
+        }
+        return $fields;
+    }
+
+    /**
+     * Private function to get the common type from the information of the field
+     */
+    private function getCommonType(string $fieldName, string $nativeType): string
+    {
+        if (isset($this->overrideTypes[$fieldName])) {
+            return $this->overrideTypes[$fieldName];
+        }
+        $nativeType = strtolower($nativeType);
+        return self::TYPES[$nativeType] ?? CommonTypes::TTEXT;
+    }
+}

--- a/src/Iterators/RecordsetIterator.php
+++ b/src/Iterators/RecordsetIterator.php
@@ -60,7 +60,7 @@ class RecordsetIterator implements Iterator
     #[\ReturnTypeWillChange]
     public function key()
     {
-        if (! count($this->keyFields)) {
+        if ([] === $this->keyFields) {
             return $this->index;
         }
 

--- a/src/Iterators/RecordsetIterator.php
+++ b/src/Iterators/RecordsetIterator.php
@@ -8,7 +8,7 @@ use EngineWorks\DBAL\Recordset;
 use Iterator;
 
 /**
- * @implements Iterator<int|string, array<string, mixed>>
+ * @implements Iterator<int|string, array<string, scalar|null>>
  */
 class RecordsetIterator implements Iterator
 {

--- a/src/Mssql/Result.php
+++ b/src/Mssql/Result.php
@@ -38,7 +38,7 @@ class Result implements ResultInterface
 
     /**
      * The place where getFields result is cached
-     * @var array<int, array<string, scalar|null>>|null
+     * @var array<int, array{name: string, table: string, commontype: string}>|null
      */
     private $cachedGetFields;
 

--- a/src/Mysqli/Result.php
+++ b/src/Mysqli/Result.php
@@ -56,7 +56,7 @@ class Result implements ResultInterface
 
     /**
      * The place where getFields result is cached
-     * @var array<int, array<string, scalar|null>>|null
+     * @var array<int, array{name: string, table: string, commontype: string, flags: int}>|null
      */
     private $cachedGetFields;
 
@@ -86,11 +86,22 @@ class Result implements ResultInterface
         $this->query->free();
     }
 
+    /**
+     * @inheritDoc
+     * @return array<int, array{name: string, table: string, commontype: string, flags: int}>
+     */
     public function getFields(): array
     {
-        if (null !== $this->cachedGetFields) {
-            return $this->cachedGetFields;
+        if (null === $this->cachedGetFields) {
+            $this->cachedGetFields = $this->obtainFields();
         }
+
+        return $this->cachedGetFields;
+    }
+
+    /** @return array<int, array{name: string, table: string, commontype: string, flags: int}> */
+    private function obtainFields(): array
+    {
         $fields = [];
         $fetchedFields = $this->query->fetch_fields() ?: [];
         foreach ($fetchedFields as $fetched) {
@@ -107,7 +118,6 @@ class Result implements ResultInterface
                 'flags' => $fetched->flags,  // extra: used for getting the ids in the query
             ];
         }
-        $this->cachedGetFields = $fields;
         return $fields;
     }
 

--- a/src/Recordset.php
+++ b/src/Recordset.php
@@ -668,7 +668,7 @@ class Recordset implements LoggerAwareInterface, IteratorAggregate, Countable
     /**
      * Return an associative array of fields, the key is the field name
      * and the content is an array containing name, common type and table
-     * @return array<string, array<string, mixed>>
+     * @return array<string, array{name: string, table: string, commontype: string}>
      */
     final public function getFields(): array
     {

--- a/src/Recordset.php
+++ b/src/Recordset.php
@@ -156,7 +156,7 @@ class Recordset implements LoggerAwareInterface, IteratorAggregate, Countable
             $this->entity = $overrideEntity;
         }
         // set the id fields if did not override
-        if (! count($overrideKeys)) {
+        if ([] === $overrideKeys) {
             $this->idFields = $this->result()->getIdFields() ?: [];
         } else {
             // validate overrideKeys
@@ -374,7 +374,7 @@ class Recordset implements LoggerAwareInterface, IteratorAggregate, Countable
             $conditions[] = "($extraWhereClause)";
         }
         $ids = $this->getIdFields();
-        if (! count($ids)) {
+        if ([] === $ids) {
             $this->getLogger()->warning('Recordset: cannot get the ids to locate the current the record,'
                 . ' will use all the fields to create the where clause'
                 . "\n"
@@ -414,7 +414,7 @@ class Recordset implements LoggerAwareInterface, IteratorAggregate, Countable
             $escapedFieldName = $this->dbal->sqlFieldEscape($field['name']);
             $inserts[$escapedFieldName] = $this->dbal->sqlQuote($value, $field['commontype'], true);
         }
-        if (! count($inserts)) {
+        if ([] === $inserts) {
             throw new LogicException('Recordset: Insert does not have any fields to insert');
         }
         return 'INSERT INTO ' . $this->dbal->sqlTableEscape($this->entity)
@@ -434,7 +434,7 @@ class Recordset implements LoggerAwareInterface, IteratorAggregate, Countable
         // get the conditions to alter the current record
         $conditions = $this->sqlWhereConditions($extraWhereClause);
         // if no conditions then log error and return false
-        if (! count($conditions)) {
+        if ([] === $conditions) {
             throw new LogicException('Recordset: The current record does not have any conditions to update');
         }
         // get the fields that have changed compared to originalValues
@@ -449,7 +449,7 @@ class Recordset implements LoggerAwareInterface, IteratorAggregate, Countable
             }
         }
         // if nothing to update, log error and return empty string
-        if (! count($updates)) {
+        if ([] === $updates) {
             return '';
         }
         // return the update statement
@@ -470,7 +470,7 @@ class Recordset implements LoggerAwareInterface, IteratorAggregate, Countable
         // get the conditions to alter the current record
         $conditions = $this->sqlWhereConditions($extraWhereClause);
         // if no conditions then log error and return false
-        if (! count($conditions)) {
+        if ([] === $conditions) {
             throw new LogicException('Recordset: The current record does not have any conditions to delete');
         }
         return 'DELETE'

--- a/src/Result.php
+++ b/src/Result.php
@@ -11,7 +11,7 @@ use IteratorAggregate;
  * Interface Result, this interface must be implemented by the Drivers
  *
  * @package EngineWorks\DBAL
- * @extends IteratorAggregate<int, array<scalar|null>>
+ * @extends IteratorAggregate<int, array<string, scalar|null>>
  */
 interface Result extends IteratorAggregate, Countable
 {
@@ -24,7 +24,7 @@ interface Result extends IteratorAggregate, Countable
     /**
      * Return an array with the information of the fields
      * Each row must contain the keys: [name, commontype, table]
-     * @return array<int, array<string, scalar|null>>
+     * @return array<int, array{name: string, table: string, commontype: string}>
      */
     public function getFields(): array;
 

--- a/src/Sqlite/DBAL.php
+++ b/src/Sqlite/DBAL.php
@@ -125,7 +125,7 @@ class DBAL extends BaseDBAL
 
     public function sqlConcatenate(...$strings): string
     {
-        if (! count($strings)) {
+        if ([] === $strings) {
             return $this->sqlQuote('', CommonTypes::TTEXT);
         }
         return implode(' || ', $strings);

--- a/src/Sqlite/Result.php
+++ b/src/Sqlite/Result.php
@@ -47,7 +47,7 @@ class Result implements ResultInterface
 
     /**
      * The place where getFields result is cached
-     * @var array<int, array<string, scalar|null>>|null
+     * @var array<int, array{name: string, table: string, commontype: string}>|null
      */
     private $cachedGetFields;
 
@@ -144,9 +144,16 @@ class Result implements ResultInterface
 
     public function getFields(): array
     {
-        if (null !== $this->cachedGetFields) {
-            return $this->cachedGetFields;
+        if (null === $this->cachedGetFields) {
+            $this->cachedGetFields = $this->obtainFields();
         }
+
+        return $this->cachedGetFields;
+    }
+
+    /** @return array<int, array{name: string, table: string, commontype: string}> */
+    private function obtainFields(): array
+    {
         $fields = [];
         $numcolumns = $this->query->numColumns();
         for ($i = 0; $i < $numcolumns; $i++) {
@@ -157,7 +164,6 @@ class Result implements ResultInterface
                 'table' => '',
             ];
         }
-        $this->cachedGetFields = $fields;
         return $fields;
     }
 

--- a/src/Sqlsrv/Result.php
+++ b/src/Sqlsrv/Result.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 namespace EngineWorks\DBAL\Sqlsrv;
 
 use EngineWorks\DBAL\CommonTypes;
+use EngineWorks\DBAL\Internal\SqlServerResultFields;
 use EngineWorks\DBAL\Result as ResultInterface;
 use EngineWorks\DBAL\Traits\ResultImplementsCountable;
 use EngineWorks\DBAL\Traits\ResultImplementsIterator;
@@ -18,32 +19,6 @@ class Result implements ResultInterface
 {
     use ResultImplementsCountable;
     use ResultImplementsIterator;
-
-    private const TYPES = [
-        // integers
-        'int' => CommonTypes::TINT,
-        'tinyint' => CommonTypes::TINT,
-        'smallint' => CommonTypes::TINT,
-        'bigint' => CommonTypes::TINT,
-        // floats
-        'float' => CommonTypes::TNUMBER,
-        'real' => CommonTypes::TNUMBER,
-        'decimal' => CommonTypes::TNUMBER,
-        'numeric' => CommonTypes::TNUMBER,
-        'money' => CommonTypes::TNUMBER,
-        'smallmoney' => CommonTypes::TNUMBER,
-        // dates
-        'date' => CommonTypes::TDATE,
-        'time' => CommonTypes::TTIME,
-        'datetime' => CommonTypes::TDATETIME,
-        'smalldatetime' => CommonTypes::TDATETIME,
-        // bool
-        'bit' => CommonTypes::TBOOL,
-        // text
-        'char' => CommonTypes::TTEXT,
-        'varchar' => CommonTypes::TTEXT,
-        'text' => CommonTypes::TTEXT,
-    ];
 
     /**
      * PDO element
@@ -65,7 +40,7 @@ class Result implements ResultInterface
 
     /**
      * The place where getFields result is cached
-     * @var array<int, array<string, scalar|null>>|null
+     * @var array<int, array{name: string, table: string, commontype: string}>|null
      */
     private $cachedGetFields;
 
@@ -100,43 +75,12 @@ class Result implements ResultInterface
 
     public function getFields(): array
     {
-        if (null !== $this->cachedGetFields) {
-            return $this->cachedGetFields;
+        if (null === $this->cachedGetFields) {
+            $typeChecker = new SqlServerResultFields($this->overrideTypes, 'sqlsrv:decl_type');
+            $this->cachedGetFields = $typeChecker->obtainFields($this->stmt);
         }
-        $columnsCount = $this->stmt->columnCount();
-        $columns = [];
-        for ($column = 0; $column < $columnsCount; $column++) {
-            $columnMeta = $this->stmt->getColumnMeta($column);
-            if (is_array($columnMeta)) {
-                $columns[] = $columnMeta;
-            }
-        }
-        $fields = [];
-        foreach ($columns as $fetched) {
-            $fields[] = [
-                'name' => $fetched['name'],
-                'commontype' => $this->getCommonType($fetched['name'], $fetched['sqlsrv:decl_type']),
-                'table' => $fetched['table'] ?? '',
-            ];
-        }
-        $this->cachedGetFields = $fields;
-        return $fields;
-    }
 
-    /**
-     * Private function to get the common type from the information of the field
-     *
-     * @param string $fieldName
-     * @param string $nativeType
-     * @return string
-     */
-    private function getCommonType(string $fieldName, string $nativeType): string
-    {
-        if (isset($this->overrideTypes[$fieldName])) {
-            return $this->overrideTypes[$fieldName];
-        }
-        $nativeType = strtolower($nativeType);
-        return self::TYPES[$nativeType] ?? CommonTypes::TTEXT;
+        return $this->cachedGetFields;
     }
 
     public function getIdFields(): bool

--- a/src/Traits/MethodSqlConcatenate.php
+++ b/src/Traits/MethodSqlConcatenate.php
@@ -11,7 +11,7 @@ trait MethodSqlConcatenate
 {
     public function sqlConcatenate(...$strings): string
     {
-        if (! count($strings)) {
+        if ([] === $strings) {
             return $this->sqlQuote('');
         }
         return 'CONCAT(' . implode(', ', $strings) . ')';

--- a/tests/Tests/DBAL/Mssql/MssqlDbalDisconnectedTest.php
+++ b/tests/Tests/DBAL/Mssql/MssqlDbalDisconnectedTest.php
@@ -32,10 +32,9 @@ final class MssqlDbalDisconnectedTest extends WithDbalTestCase
             'info: -- Connection fail',
             'error: ',
         ];
-        $expectedLogsCount = count($expectedLogs);
         $actualLogs = $this->logger->allMessages();
-        for ($i = 0; $i < $expectedLogsCount; $i++) {
-            $this->assertStringStartsWith($expectedLogs[$i], $actualLogs[$i]);
+        foreach ($expectedLogs as $i => $expectedLog) {
+            $this->assertStringStartsWith($expectedLog, $actualLogs[$i]);
         }
     }
 

--- a/tests/Tests/DBAL/Mysqli/MysqliDisconnectedTest.php
+++ b/tests/Tests/DBAL/Mysqli/MysqliDisconnectedTest.php
@@ -34,10 +34,9 @@ class MysqliDisconnectedTest extends WithDbalTestCase
             'info: -- Connection fail',
             'error: ',
         ];
-        $expectedLogsCount = count($expectedLogs);
         $actualLogs = $this->logger->allMessages();
-        for ($i = 0; $i < $expectedLogsCount; $i++) {
-            $this->assertStringStartsWith($expectedLogs[$i], $actualLogs[$i]);
+        foreach ($expectedLogs as $i => $expectedLog) {
+            $this->assertStringStartsWith($expectedLog, $actualLogs[$i]);
         }
     }
 

--- a/tests/Tests/DBAL/Sqlsrv/SqlsrvConnectFailuresTest.php
+++ b/tests/Tests/DBAL/Sqlsrv/SqlsrvConnectFailuresTest.php
@@ -28,10 +28,9 @@ class SqlsrvConnectFailuresTest extends WithDbalTestCase
             'info: -- Connection fail',
             'error: ',
         ];
-        $expectedLogsCount = count($expectedLogs);
         $actualLogs = $this->logger->allMessages();
-        for ($i = 0; $i < $expectedLogsCount; $i++) {
-            $this->assertStringStartsWith($expectedLogs[$i], $actualLogs[$i]);
+        foreach ($expectedLogs as $i => $expectedLog) {
+            $this->assertStringStartsWith($expectedLog, $actualLogs[$i]);
         }
     }
 

--- a/tests/Tests/DBAL/TesterCases/RecordsetTester.php
+++ b/tests/Tests/DBAL/TesterCases/RecordsetTester.php
@@ -68,7 +68,7 @@ final class RecordsetTester
         $recordset = $this->test->createRecordset($sql, 'albums', ['albumid']);
         $this->test->assertSame($sql, $recordset->getSource());
         $this->test->assertSame(45, $recordset->getRecordCount());
-        $this->test->assertSame(45, count($recordset));
+        $this->test->assertCount(45, $recordset);
         for ($i = 1; $i <= 45; $i++) {
             $this->test->assertFalse($recordset->eof());
             $this->test->assertSame($i, $recordset->values['albumid']);

--- a/tests/Tests/WithDatabaseTestCase.php
+++ b/tests/Tests/WithDatabaseTestCase.php
@@ -71,9 +71,8 @@ abstract class WithDatabaseTestCase extends WithDbalTestCase
     {
         $array = $this->getFixedValues($idFrom, $idTo);
         $keys = ['albumid', 'title', 'votes', 'lastview', 'isfree', 'collect'];
-        $count = count($array);
-        for ($i = 0; $i < $count; $i++) {
-            $array[$i] = array_combine($keys, $array[$i]) ?: [];
+        foreach ($array as $i => $item) {
+            $array[$i] = array_combine($keys, $item) ?: [];
         }
         return $array;
     }


### PR DESCRIPTION
- Improve typing on `Recordset` and `RecordsetIterator`.
- Improve comparison to check for empty arrays, avoid `count`.
- Refactor and improve logic for `Result::getFields()`.
