### PR TITLE
Maintenance and compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,22 +80,10 @@ jobs:
       - name: Update APT repositories
         run: |
           sudo apt-get update -y -qq
-      # - name: Configure microsoft repository
-      #   run: |
-      #     sudo apt-get install -y -qq gnupg2
-      #     sudo curl --no-progress-meter https://packages.microsoft.com/keys/microsoft.asc -o /etc/apt/trusted.gpg.d/microsoft.asc
-      #     sudo curl --no-progress-meter https://packages.microsoft.com/config/ubuntu/$(lsb_release -sr)/prod.list -o /etc/apt/sources.list.d/microsoft.list
-      #     sudo apt-get update -y -qq
       - name: Install locales
         run: |
           sudo apt-get install -y -qq tzdata locales
           sudo locale-gen en_US.UTF-8 en_US pt_BR
-      - name: Install packages
-        run: |
-          export MSODBCSQL=$(php -r "echo (PHP_VERSION_ID >= 74000) ? 'msodbcsql18' : 'msodbcsql17'")
-          sudo apt-get install -y -qq $MSODBCSQL mssql-tools unixodbc unixodbc-dev
-        env:
-          ACCEPT_EULA: Y
       - name: Set up environment file
         run: |
           test -e tests/.env || cp -v tests/.env.github tests/.env

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,9 @@
 name: build
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ "main" ]
   push:
-    branches: [ main ]
+    branches: [ "main" ]
 #  schedule:
 #    - cron: '0 16 * * 0' # sunday 16:00
 
@@ -78,7 +78,7 @@ jobs:
       - name: Update APT repositories
         run: |
           sudo apt-get update -y -qq
-      # - name: Configute microsoft repository
+      # - name: Configure microsoft repository
       #   run: |
       #     sudo apt-get install -y -qq gnupg2
       #     sudo curl --no-progress-meter https://packages.microsoft.com/keys/microsoft.asc -o /etc/apt/trusted.gpg.d/microsoft.asc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,6 +97,8 @@ jobs:
           tools: composer:v2
         env:
           fail-fast: true
+      - name: Show PHP information
+        run: php --info
       - name: Get composer cache directory
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,7 +110,7 @@ jobs:
           fail-fast: true
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
         uses: actions/cache@v3
         with:
@@ -147,7 +147,7 @@ jobs:
           fail-fast: true
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
         uses: actions/cache@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.2'
           coverage: none
           tools: cs2pr, phpcs
         env:
@@ -37,13 +37,15 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.2'
           coverage: none
           tools: cs2pr, php-cs-fixer
         env:
           fail-fast: true
       - name: Coding standards (php-cs-fixer)
         run: php-cs-fixer fix --dry-run --format=checkstyle | cs2pr
+        env:
+          PHP_CS_FIXER_IGNORE_ENV: 1
 
   phpunit:
     name: Tests on PHP ${{ matrix.php-versions }} (phpunit)
@@ -64,7 +66,7 @@ jobs:
           --health-retries 3
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0', '8.1']
+        php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2']
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -138,7 +140,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.2'
           coverage: none
           tools: composer:v2, phpstan
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ on:
 
 # Actions
 # shivammathur/setup-php - https://github.com/marketplace/actions/setup-php-action
+# sudo-bot/action-scrutinizer - https://github.com/marketplace/actions/action-scrutinizer
 
 jobs:
   phpcs:
@@ -71,7 +72,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          fetch-depth: "0" # required for scrutinizer/ocular
+          fetch-depth: "0" # required for sudo-bot/action-scrutinizer
       - name: Start MySQL # mysql is already installed on virtual-environments
         run: |
           sudo systemctl start mysql.service
@@ -113,10 +114,9 @@ jobs:
           testMssql_port: ${{ job.services.mssql.ports[1433] }}
           testSqlsrv_port: ${{ job.services.mssql.ports[1433] }}
       - name: Upload code coverage to scrutinizer
-        run: |
-          mkdir -p build/scrutinizer
-          composer require scrutinizer/ocular:dev-master --working-dir=build/scrutinizer --no-progress
-          php build/scrutinizer/vendor/bin/ocular code-coverage:upload -vvv --no-interaction --format=php-clover build/coverage-clover.xml
+        uses: sudo-bot/action-scrutinizer@latest
+        with:
+          cli-args: "--format=php-clover build/coverage-clover.xml"
         continue-on-error: true
 
   phpstan:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,9 +88,10 @@ jobs:
         run: |
           sudo apt-get install -y -qq tzdata locales
           sudo locale-gen en_US.UTF-8 en_US pt_BR
-      - name: Install unixodbc-dev
+      - name: Install packages
         run: |
-          sudo apt-get install -y -qq msodbcsql17 mssql-tools unixodbc unixodbc-dev
+          export MSODBCSQL=$(php -r "echo (PHP_VERSION_ID >= 74000) ? 'msodbcsql18' : 'msodbcsql17'")
+          sudo apt-get install -y -qq $MSODBCSQL mssql-tools unixodbc unixodbc-dev
         env:
           ACCEPT_EULA: Y
       - name: Set up environment file

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -2,6 +2,6 @@
 <phive xmlns="https://phar.io/phive">
   <phar name="phpcs" version="^3.7.1" installed="3.7.1" location="./tools/phpcs" copy="false"/>
   <phar name="phpcbf" version="^3.7.1" installed="3.7.1" location="./tools/phpcbf" copy="false"/>
-  <phar name="php-cs-fixer" version="^3.9.5" installed="3.9.5" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpstan" version="^1.8.2" installed="1.8.2" location="./tools/phpstan" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.14.4" installed="3.14.4" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpstan" version="^1.9.17" installed="1.9.17" location="./tools/phpstan" copy="false"/>
 </phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -18,18 +18,17 @@ return (new PhpCsFixer\Config())
         '@PHP71Migration:risky' => true,
         '@PHP73Migration' => true,
         // symfony
-        'ordered_imports' => ['imports_order' => ['class', 'function', 'const']], // @PSR12 sort_algorithm: none
-        'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['arrays']], // different from PHP73Migration
         'class_attributes_separation' => true,
         'whitespace_after_comma_in_array' => true,
         'no_empty_statement' => true,
         'no_extra_blank_lines' => true,
         'function_typehint_space' => true,
+        'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['arrays']],
         'no_blank_lines_after_phpdoc' => true,
         'object_operator_without_whitespace' => true,
         'binary_operator_spaces' => true,
         'phpdoc_scalar' => true,
-        'no_trailing_comma_in_singleline_array' => true,
+        'no_trailing_comma_in_singleline' => true,
         'single_quote' => true,
         'no_singleline_whitespace_before_semicolons' => true,
         'no_unused_imports' => true,
@@ -43,6 +42,7 @@ return (new PhpCsFixer\Config())
         'self_accessor' => true,
         // contrib
         'not_operator_with_successor_space' => true,
+        'ordered_imports' => ['imports_order' => ['class', 'function', 'const']], // @PSR12 sort_algorithm: none
     ])
     ->setFinder(
         PhpCsFixer\Finder::create()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Improve code style for `php-cs-fixer` tool.
 - Update tests since methods `expectNotice` and `expectDeprecation` are deprecated.
 - GitHub build workflow:
+  - Show PHP information on `phpunit` job to display modules versions.
   - Add PHP 8.2 to test matrix. 
   - No need to install `msodbcsql17|msodbcsql18`, `mssql-tools`, `unixodbc` or `unixodbc-dev`.
   - Run workflows on PHP 8.2.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@
 - Update development tools.
 - Improve code style for `php-cs-fixer` tool.
 - Update tests since methods `expectNotice` and `expectDeprecation` are deprecated.
-- GitHub build workflow
-  - Install `msodbcsql18` instead of `msodbcsql17` when PHP greater or equal than 7.4.
+- GitHub build workflow:
+  - Add PHP 8.2 to test matrix. 
+  - No need to install `msodbcsql17|msodbcsql18`, `mssql-tools`, `unixodbc` or `unixodbc-dev`.
   - Run workflows on PHP 8.2.
   - Use `GITHUB_OUTPUT` instead of `set-output`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   - No need to install `msodbcsql17|msodbcsql18`, `mssql-tools`, `unixodbc` or `unixodbc-dev`.
   - Run workflows on PHP 8.2.
   - Use `GITHUB_OUTPUT` instead of `set-output`.
+  - Use `sudo-bot/action-scrutinizer` action instead of install package `scrutinizer/ocular`.
 
 # Version 2.3.3 2022-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 - See [Version 3](VERSION_3.md) for major changes
 
+# Version 2.3.4 2023-02-15
+
+- Add `psr/log: ^3.0` as a dependency.
+- Update license year. Happy 2023!
+- Update development tools.
+- Improve code style for `php-cs-fixer` tool.
+- Update tests since methods `expectNotice` and `expectDeprecation` are deprecated.
+- GitHub build workflow
+  - Install `msodbcsql18` instead of `msodbcsql17` when PHP greater or equal than 7.4.
+  - Run workflows on PHP 8.2.
+  - Use `GITHUB_OUTPUT` instead of `set-output`.
+
 # Version 2.3.3 2022-08-15
 
 - Add compatibility with `psr/log` version 2.0.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,5 +127,5 @@ As documented in [`actions/setup-php-action`](https://github.com/marketplace/act
 you will need to execute the command as:
 
 ```shell
-act -P ubuntu-latest=shivammathur/node:latest
+act --artifact-server-path build/artifacts -P ubuntu-latest=shivammathur/node:2204
 ```

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2013 - 2022 Carlos C Soto
+Copyright (c) 2013 - 2023 Carlos C Soto
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ and licensed for use under the MIT License (MIT). Please see [LICENSE][] for mor
 [badge-source]: https://img.shields.io/badge/source-eclipxe13/engineworks--dbal-blue?style=flat-square
 [badge-release]: https://img.shields.io/github/release/eclipxe13/engineworks-dbal?style=flat-square
 [badge-license]: https://img.shields.io/github/license/eclipxe13/engineworks-dbal?style=flat-square
-[badge-build]: https://img.shields.io/github/workflow/status/eclipxe13/engineworks-dbal/build/main?style=flat-square
+[badge-build]: https://img.shields.io/github/actions/workflow/status/eclipxe13/engineworks-dbal/build.yml?branch=main&style=flat-square
 [badge-quality]: https://img.shields.io/scrutinizer/quality/g/eclipxe13/engineworks-dbal/main?style=flat-square
 [badge-coverage]: https://img.shields.io/scrutinizer/coverage/g/eclipxe13/engineworks-dbal/main?style=flat-square
 [badge-downloads]: https://img.shields.io/packagist/dt/eclipxe/engineworks-dbal?style=flat-square

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": ">=7.3",
         "ext-ctype": "*",
-        "psr/log": "^1.1|^2.0"
+        "psr/log": "^1.1|^2.0|^3.0"
     },
     "require-dev": {
         "ext-PDO": "*",

--- a/src/Internal/SqlServerResultFields.php
+++ b/src/Internal/SqlServerResultFields.php
@@ -63,7 +63,10 @@ final class SqlServerResultFields
         foreach ($columns as $fetched) {
             $fields[] = [
                 'name' => $fetched['name'],
-                'commontype' => $this->getCommonType($fetched['name'], $fetched[$this->nativeTypeKey]),
+                'commontype' => $this->getCommonType(
+                    $fetched['name'],
+                    is_scalar($fetched[$this->nativeTypeKey]) ? (string) $fetched[$this->nativeTypeKey] : ''
+                ),
                 'table' => $fetched['table'] ?? '',
             ];
         }

--- a/tests/Tests/DBAL/TesterTraits/DbalQueriesTrait.php
+++ b/tests/Tests/DBAL/TesterTraits/DbalQueriesTrait.php
@@ -382,21 +382,30 @@ trait DbalQueriesTrait
     public function testSqlIsNullWithNegationTriggerNotice(): void
     {
         $dbal = $this->getDbal();
-        $this->expectNotice();
-        $dbal->sqlIsNull('foo', false);
+
+        error_clear_last();
+        @$dbal->sqlIsNull('foo', false);
+        $error = error_get_last() ?: [];
+        $this->assertSame(E_USER_NOTICE, intval($error['type'] ?? 0));
     }
 
     public function testSqlInWithNegationTriggerNotice(): void
     {
         $dbal = $this->getDbal();
-        $this->expectNotice();
-        $dbal->sqlIn('foo', ['bar', 'baz'], CommonTypes::TTEXT, false);
+
+        error_clear_last();
+        @$dbal->sqlIn('foo', ['bar', 'baz'], CommonTypes::TTEXT, false);
+        $error = error_get_last() ?: [];
+        $this->assertSame(E_USER_NOTICE, intval($error['type'] ?? 0));
     }
 
     public function testQueryTriggerDeprecation(): void
     {
         $dbal = $this->getDbal();
-        $this->expectDeprecation();
-        $dbal->query('SELECT 1');
+
+        error_clear_last();
+        @$dbal->query('SELECT 1');
+        $error = error_get_last() ?: [];
+        $this->assertSame(E_USER_DEPRECATED, intval($error['type'] ?? 0));
     }
 }

--- a/tests/Tests/DBAL/TesterTraits/TransactionsWithExceptionsTestTrait.php
+++ b/tests/Tests/DBAL/TesterTraits/TransactionsWithExceptionsTestTrait.php
@@ -1,5 +1,7 @@
 <?php
 
+/** @noinspection PhpUsageOfSilenceOperatorInspection */
+
 declare(strict_types=1);
 
 namespace EngineWorks\DBAL\Tests\DBAL\TesterTraits;
@@ -12,13 +14,17 @@ trait TransactionsWithExceptionsTestTrait
 
     public function testCommitThrowsWarningWithOutBegin(): void
     {
-        $this->expectNotice();
-        $this->getDbal()->transCommit();
+        error_clear_last();
+        @$this->getDbal()->transCommit();
+        $error = error_get_last() ?: [];
+        $this->assertSame(E_USER_NOTICE, intval($error['type'] ?? 0));
     }
 
     public function testRollbackThrowsWarningWithOutBegin(): void
     {
-        $this->expectNotice();
-        $this->getDbal()->transRollback();
+        error_clear_last();
+        @$this->getDbal()->transRollback();
+        $error = error_get_last() ?: [];
+        $this->assertSame(E_USER_NOTICE, intval($error['type'] ?? 0));
     }
 }

--- a/tests/sqlsrv-direct-connection.php
+++ b/tests/sqlsrv-direct-connection.php
@@ -3,10 +3,11 @@
 declare(strict_types=1);
 
 //
-// This script does not depends on anything, it only check connection to ms sql server
+// This script does not depend on anything, it only checks connection to ms sql server
+// php sqlsrv-direct-connection.php server user password database
 //
 
-exit(call_user_func(function ($arguments): int {
+exit(call_user_func(function (string ...$arguments): int {
     $host = $arguments[1] ?? 'localhost';
     $user = $arguments[2] ?? '';
     $pass = $arguments[3] ?? '';
@@ -34,4 +35,4 @@ exit(call_user_func(function ($arguments): int {
         return 1;
     }
     return 0;
-}, $argv));
+}, ...$argv));


### PR DESCRIPTION
- Add `psr/log: ^3.0` as a dependency.
- Update license year. Happy 2023!
- Update development tools.
- Improve code style for `php-cs-fixer` tool.
- Update tests since methods `expectNotice` and `expectDeprecation` are deprecated.
- GitHub build workflow
  - Install `msodbcsql18` instead of `msodbcsql17` when PHP greater or equal than 7.4.
  - Run workflows on PHP 8.2.
  - Use `GITHUB_OUTPUT` instead of `set-output`.