### PR TITLE
Version 2.3.5 & maintenance

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,8 +45,6 @@ jobs:
           fail-fast: true
       - name: Coding standards (php-cs-fixer)
         run: php-cs-fixer fix --dry-run --format=checkstyle | cs2pr
-        env:
-          PHP_CS_FIXER_IGNORE_ENV: 1
 
   phpunit:
     name: Tests on PHP ${{ matrix.php-version }} (phpunit)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,9 +105,9 @@ jobs:
       - name: Cache dependencies
         uses: actions/cache@v4
         with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-composer-
+          path: "${{ steps.composer-cache.outputs.dir }}"
+          key: "${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}"
+          restore-keys: "${{ runner.os }}-composer-"
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist
       - name: Tests (phpunit)
@@ -141,9 +141,9 @@ jobs:
       - name: Cache dependencies
         uses: actions/cache@v4
         with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-composer-
+          path: "${{ steps.composer-cache.outputs.dir }}"
+          key: "${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}"
+          restore-keys: "${{ runner.os }}-composer-"
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist
       - name: Static analysis (phpstan)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
           --health-retries 3
     strategy:
       matrix:
-        php-version: ['7.3', '7.4', '8.0', '8.1', '8.2']
+        php-version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -34,7 +34,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -70,7 +70,7 @@ jobs:
         php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2']
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: "0" # required for sudo-bot/action-scrutinizer
       - name: Start MySQL # mysql is already installed on virtual-environments
@@ -103,7 +103,7 @@ jobs:
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -126,7 +126,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -139,7 +139,7 @@ jobs:
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
           PHP_CS_FIXER_IGNORE_ENV: 1
 
   phpunit:
-    name: Tests on PHP ${{ matrix.php-versions }} (phpunit)
+    name: Tests on PHP ${{ matrix.php-version }} (phpunit)
     runs-on: "ubuntu-latest"
     services:
       mssql:
@@ -67,7 +67,7 @@ jobs:
           --health-retries 3
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2']
+        php-version: ['7.3', '7.4', '8.0', '8.1', '8.2']
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -91,7 +91,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-versions }}
+          php-version: ${{ matrix.php-version }}
           extensions: pdo, sqlite3, mysqli, pdo_sqlsrv, pdo_dblib
           coverage: xdebug
           tools: composer:v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: none
           tools: cs2pr, phpcs
         env:
@@ -38,7 +38,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: none
           tools: cs2pr, php-cs-fixer
         env:
@@ -130,7 +130,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: none
           tools: composer:v2, phpstan
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,10 +78,10 @@ jobs:
             "CREATE USER 'admin'@'localhost' IDENTIFIED WITH mysql_native_password BY 'Password-123456' ; GRANT ALL PRIVILEGES ON *.* TO 'admin'@'localhost' ;"
       - name: Update APT repositories
         run: |
-          sudo apt-get update -y -qq
+          sudo apt-get -yqq update
       - name: Install locales
         run: |
-          sudo apt-get install -y -qq tzdata locales
+          sudo apt-get -yqq install tzdata locales
           sudo locale-gen en_US.UTF-8 en_US pt_BR
       - name: Set up environment file
         run: |

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="phpcs" version="^3.7.1" installed="3.7.1" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.7.1" installed="3.7.1" location="./tools/phpcbf" copy="false"/>
-  <phar name="php-cs-fixer" version="^3.14.4" installed="3.14.4" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpstan" version="^1.9.17" installed="1.9.17" location="./tools/phpstan" copy="false"/>
+  <phar name="phpcs" version="^3.9.2" installed="3.9.2" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^3.9.2" installed="3.9.2" location="./tools/phpcbf" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.54.0" installed="3.54.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpstan" version="^1.10.67" installed="1.10.67" location="./tools/phpstan" copy="false"/>
 </phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -22,7 +22,7 @@ return (new PhpCsFixer\Config())
         'whitespace_after_comma_in_array' => true,
         'no_empty_statement' => true,
         'no_extra_blank_lines' => true,
-        'function_typehint_space' => true,
+        'type_declaration_spaces' => true,
         'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['arrays']],
         'no_blank_lines_after_phpdoc' => true,
         'object_operator_without_whitespace' => true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 - See [Version 3](VERSION_3.md) for major changes
 
+# Version 2.3.5 2024-04-29
+
+- Allow to receive PHP Enums as value to quote.
+  - For regular enums (`UnitEnum`) is parsed as the enum name.
+  - For backed enums (`BackedEnum`) is parsed as the enum value.
+- Avoid calling Sqlite3 to disable exceptions `Sqlite3::enableExceptions(false)` since it is deprecated now.
+- Introduce method to convert object to string.
+- Update license year to 2024.
+- Improve code style for `php-cs-fixer` tool.
+- GitHub build workflow:
+  - Add PHP 8.3 to test matrix.
+  - Run jobs using PHP 8.3.
+  - Quote strings.
+  - Remove `PHP_CS_FIXER_IGNORE_ENV` when running `php-cs-fixer`.
+- Update development tools.
+
 # Version 2.3.4 2023-02-15
 
 - Add `psr/log: ^3.0` as a dependency.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,5 +127,5 @@ As documented in [`actions/setup-php-action`](https://github.com/marketplace/act
 you will need to execute the command as:
 
 ```shell
-act --artifact-server-path build/artifacts -P ubuntu-latest=shivammathur/node:2204
+act -P ubuntu-latest=shivammathur/node:2204
 ```

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2013 - 2023 Carlos C Soto
+Copyright (c) 2013 - 2024 Carlos C Soto
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Abstracts/BaseDBAL.php
+++ b/src/Abstracts/BaseDBAL.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace EngineWorks\DBAL\Abstracts;
 
+use BackedEnum;
 use EngineWorks\DBAL\CommonTypes;
 use EngineWorks\DBAL\DBAL;
 use EngineWorks\DBAL\Exceptions\QueryException;
@@ -17,6 +18,7 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use RuntimeException;
 use Throwable;
+use UnitEnum;
 
 abstract class BaseDBAL implements DBAL
 {
@@ -191,6 +193,11 @@ abstract class BaseDBAL implements DBAL
         string $commonType = CommonTypes::TTEXT,
         bool $includeNull = false
     ): string {
+        if (PHP_VERSION_ID > 80100) { // PHP 8.1
+            if ($variable instanceof UnitEnum) { // BackedEnum implements UnitEnum
+                $variable = $variable instanceof BackedEnum ? $variable->value : $variable->name;
+            }
+        }
         if (is_object($variable)) {
             $variable = $this->convertObjectToString($variable);
         }

--- a/src/Abstracts/BaseDBAL.php
+++ b/src/Abstracts/BaseDBAL.php
@@ -7,6 +7,7 @@ namespace EngineWorks\DBAL\Abstracts;
 use EngineWorks\DBAL\CommonTypes;
 use EngineWorks\DBAL\DBAL;
 use EngineWorks\DBAL\Exceptions\QueryException;
+use EngineWorks\DBAL\Internal\ConvertObjectToStringMethod;
 use EngineWorks\DBAL\Internal\NumericParser;
 use EngineWorks\DBAL\Pager;
 use EngineWorks\DBAL\Recordset;
@@ -15,11 +16,12 @@ use InvalidArgumentException;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use RuntimeException;
-use Stringable;
 use Throwable;
 
 abstract class BaseDBAL implements DBAL
 {
+    use ConvertObjectToStringMethod;
+
     /** @var LoggerInterface */
     protected $logger;
 
@@ -190,15 +192,7 @@ abstract class BaseDBAL implements DBAL
         bool $includeNull = false
     ): string {
         if (is_object($variable)) {
-            if (class_exists(Stringable::class) && $variable instanceof Stringable) {
-                $variable = strval($variable);
-            } elseif (is_callable([$variable, '__toString'])) {
-                $variable = strval($variable);
-            } else {
-                throw new InvalidArgumentException(
-                    sprintf('Value of type %s that cannot be parsed as scalar', get_class($variable))
-                );
-            }
+            $variable = $this->convertObjectToString($variable);
         }
         if ($includeNull && null === $variable) {
             return 'NULL';

--- a/src/Abstracts/BaseDBAL.php
+++ b/src/Abstracts/BaseDBAL.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace EngineWorks\DBAL\Abstracts;
 
-use BackedEnum;
 use EngineWorks\DBAL\CommonTypes;
 use EngineWorks\DBAL\DBAL;
 use EngineWorks\DBAL\Exceptions\QueryException;
@@ -18,7 +17,6 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use RuntimeException;
 use Throwable;
-use UnitEnum;
 
 abstract class BaseDBAL implements DBAL
 {
@@ -193,11 +191,6 @@ abstract class BaseDBAL implements DBAL
         string $commonType = CommonTypes::TTEXT,
         bool $includeNull = false
     ): string {
-        if (PHP_VERSION_ID > 80100) { // PHP 8.1
-            if ($variable instanceof UnitEnum) { // BackedEnum implements UnitEnum
-                $variable = $variable instanceof BackedEnum ? $variable->value : $variable->name;
-            }
-        }
         if (is_object($variable)) {
             $variable = $this->convertObjectToString($variable);
         }

--- a/src/Internal/ConvertObjectToStringMethod.php
+++ b/src/Internal/ConvertObjectToStringMethod.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EngineWorks\DBAL\Internal;
+
+use InvalidArgumentException;
+use Stringable;
+
+trait ConvertObjectToStringMethod
+{
+    /**
+     * @param object $variable
+     * @return string
+     */
+    private static function convertObjectToString(object $variable): string
+    {
+        if (class_exists(Stringable::class) && $variable instanceof Stringable) {
+            return strval($variable);
+        }
+        if (is_callable([$variable, '__toString'])) {
+            return $variable->__toString();
+        }
+
+        throw new InvalidArgumentException(
+            sprintf('Value of type %s that cannot be parsed as string', get_class($variable))
+        );
+    }
+}

--- a/src/Internal/ConvertObjectToStringMethod.php
+++ b/src/Internal/ConvertObjectToStringMethod.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace EngineWorks\DBAL\Internal;
 
+use BackedEnum;
 use InvalidArgumentException;
 use Stringable;
+use UnitEnum;
 
 trait ConvertObjectToStringMethod
 {
@@ -15,6 +17,11 @@ trait ConvertObjectToStringMethod
      */
     private static function convertObjectToString(object $variable): string
     {
+        if (PHP_VERSION_ID > 80100) { // PHP 8.1
+            if ($variable instanceof UnitEnum) { // BackedEnum implements UnitEnum
+                return ($variable instanceof BackedEnum) ? strval($variable->value) : $variable->name;
+            }
+        }
         if (class_exists(Stringable::class) && $variable instanceof Stringable) {
             return strval($variable);
         }

--- a/src/Internal/NumericParser.php
+++ b/src/Internal/NumericParser.php
@@ -11,6 +11,8 @@ namespace EngineWorks\DBAL\Internal;
  */
 class NumericParser
 {
+    use ConvertObjectToStringMethod;
+
     /**
      * Contains the running locale information
      * @var array{decimal_point: string, thousands_sep: string, currency_symbol: string}|null
@@ -31,7 +33,7 @@ class NumericParser
 
         // is object, convert to string
         if (is_object($value)) {
-            $value = strval($value);
+            $value = $this->convertObjectToString($value);
         }
         // is not string, early exit with 0
         if (! is_string($value)) {

--- a/src/Recordset.php
+++ b/src/Recordset.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace EngineWorks\DBAL;
 
 use Countable;
+use EngineWorks\DBAL\Internal\ConvertObjectToStringMethod;
 use InvalidArgumentException;
 use IteratorAggregate;
 use LogicException;
@@ -19,6 +20,8 @@ use RuntimeException;
  */
 class Recordset implements LoggerAwareInterface, IteratorAggregate, Countable
 {
+    use ConvertObjectToStringMethod;
+
     public const RSMODE_NOTCONNECTED = 0;
 
     public const RSMODE_CONNECTED_EDIT = 1;
@@ -342,7 +345,7 @@ class Recordset implements LoggerAwareInterface, IteratorAggregate, Countable
         }
         // do not continue using the object, convert to string
         if (is_object($current)) {
-            $current = strval($current);
+            $current = self::convertObjectToString($current);
         }
         // strict comparison if types are strings
         if (is_string($original) && is_string($current)) {

--- a/src/Sqlite/DBAL.php
+++ b/src/Sqlite/DBAL.php
@@ -49,7 +49,10 @@ class DBAL extends BaseDBAL
         }
         // OK, we are connected
         $this->logger->info('-- Connection success');
-        $this->sqlite()->enableExceptions((bool) $this->settings->get('enable-exceptions', false));
+        $enableExceptions = (bool) $this->settings->get('enable-exceptions', false);
+        if ($enableExceptions) {
+            $this->sqlite()->enableExceptions(true);
+        }
         return true;
     }
 

--- a/tests/.env.github
+++ b/tests/.env.github
@@ -20,7 +20,7 @@ testSqlsrv_connect_timeout = '5'
 testSqlsrv_timeout = '5'
 
 # set when is going to test Mysqli [yes/no], default is no so all mysql test are skipped
-# see https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md
+# see https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md
 testMysqli = 'yes'
 testMysqli_server = 'localhost'
 testMysqli_port = '3306'

--- a/tests/Tests/DBAL/TesterCases/SqlQuoteTester.php
+++ b/tests/Tests/DBAL/TesterCases/SqlQuoteTester.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace EngineWorks\DBAL\Tests\DBAL\TesterCases;
 
 use EngineWorks\DBAL\DBAL;
+use EngineWorks\DBAL\Tests\Utils\ExampleEnum;
+use EngineWorks\DBAL\Tests\Utils\ExampleIntegerBackedEnum;
+use EngineWorks\DBAL\Tests\Utils\ExampleStringBackedEnum;
 use EngineWorks\DBAL\Tests\WithDbalTestCase;
 use PHPUnit\Framework\TestCase;
 use SimpleXMLElement;
@@ -47,6 +50,7 @@ final class SqlQuoteTester
             $this->testSqlQuoteWithLocale(...$arguments);
         }
         $this->testWithInvalidCommonType();
+        $this->testWithEnum();
     }
 
     /** @return array<string, array{string, scalar|object|null, string, bool}> */
@@ -171,5 +175,26 @@ final class SqlQuoteTester
     public function testWithInvalidCommonType(): void
     {
         $this->test->assertSame("'Ñu'", $this->dbal->sqlQuote('Ñu', 'NON-EXISTENT-COMMONTYPE'));
+    }
+
+    public function testWithEnum(): void
+    {
+        if (PHP_VERSION_ID < 80100) { // PHP 8.1
+            return;
+        }
+        // Regular Enum
+        $unitEnum = ExampleEnum::Foo;
+        $expectedQuotedValue = $this->dbal->sqlQuote($unitEnum->name, DBAL::TTEXT);
+        $this->test->assertSame($expectedQuotedValue, $this->dbal->sqlQuote($unitEnum, DBAL::TTEXT));
+
+        // String Enum
+        $backedStringEnum = ExampleStringBackedEnum::Foo;
+        $expectedQuotedValue = $this->dbal->sqlQuote($backedStringEnum->value, DBAL::TTEXT);
+        $this->test->assertSame($expectedQuotedValue, $this->dbal->sqlQuote($backedStringEnum, DBAL::TTEXT));
+
+        // Integer Enum
+        $backedIntegerEnum = ExampleIntegerBackedEnum::Foo;
+        $expectedQuotedValue = $this->dbal->sqlQuote($backedIntegerEnum->value, DBAL::TINT);
+        $this->test->assertSame($expectedQuotedValue, $this->dbal->sqlQuote($backedIntegerEnum, DBAL::TINT));
     }
 }

--- a/tests/Tests/Utils/ExampleEnum.php
+++ b/tests/Tests/Utils/ExampleEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EngineWorks\DBAL\Tests\Utils;
+
+enum ExampleEnum
+{
+    case Foo;
+    case Bar;
+}

--- a/tests/Tests/Utils/ExampleIntegerBackedEnum.php
+++ b/tests/Tests/Utils/ExampleIntegerBackedEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EngineWorks\DBAL\Tests\Utils;
+
+enum ExampleIntegerBackedEnum: int
+{
+    case Foo = 111;
+    case Bar = 222;
+}

--- a/tests/Tests/Utils/ExampleStringBackedEnum.php
+++ b/tests/Tests/Utils/ExampleStringBackedEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EngineWorks\DBAL\Tests\Utils;
+
+enum ExampleStringBackedEnum: string
+{
+    case Foo = 'foo';
+    case Bar = 'bar';
+}


### PR DESCRIPTION
- Allow to receive PHP Enums as value to quote.
  - For regular enums (`UnitEnum`) is parsed as the enum name.
  - For backed enums (`BackedEnum`) is parsed as the enum value.
- Avoid calling Sqlite3 to disable exceptions `Sqlite3::enableExceptions(false)` since it is deprecated now.
- Introduce method to convert object to string.
- Update license year to 2024.
- Improve code style for `php-cs-fixer` tool.
- GitHub build workflow:
  - Add PHP 8.3 to test matrix.
  - Run jobs using PHP 8.3.
  - Quote strings.
  - Remove `PHP_CS_FIXER_IGNORE_ENV` when running `php-cs-fixer`.
- Update development tools.
