### PR TITLE
PHP 8.5 test compatibility and maintenance (version 2.3.7)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           coverage: none
           tools: cs2pr, php-cs-fixer
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ on:
 
 # Actions
 # shivammathur/setup-php - https://github.com/marketplace/actions/setup-php-action
+# SonarSource/sonarqube-scan-action@v6 https://github.com/marketplace/actions/official-sonarqube-scan
 
 jobs:
   phpcs:
@@ -194,6 +195,6 @@ jobs:
           sed 's#'$GITHUB_WORKSPACE'#/github/workspace#g' build/coverage/junit.xml > build/sonar-junit.xml
           sed 's#'$GITHUB_WORKSPACE'#/github/workspace#g' build/coverage/clover.xml > build/sonar-coverage.xml
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@v5
+        uses: SonarSource/sonarqube-scan-action@v6
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
           --health-retries 3
     strategy:
       matrix:
-        php-version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php-version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="phpcs" version="^3.13.2" installed="3.13.2" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.13.2" installed="3.13.2" location="./tools/phpcbf" copy="false"/>
-  <phar name="php-cs-fixer" version="^3.75.0" installed="3.75.0" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpstan" version="^2.1.17" installed="2.1.17" location="./tools/phpstan" copy="false"/>
+  <phar name="phpcs" version="^4.0.1" installed="4.0.1" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^4.0.1" installed="4.0.1" location="./tools/phpcbf" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.91.3" installed="3.91.3" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpstan" version="^2.1.33" installed="2.1.33" location="./tools/phpstan" copy="false"/>
 </phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -15,8 +15,8 @@ return (new PhpCsFixer\Config())
     ->setRules([
         '@PSR12' => true,
         '@PSR12:risky' => true,
-        '@PHP71Migration:risky' => true,
-        '@PHP73Migration' => true,
+        '@PHP7x1Migration:risky' => true,
+        '@PHP7x3Migration' => true,
         // symfony
         'class_attributes_separation' => true,
         'whitespace_after_comma_in_array' => true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 - See [Version 3](VERSION_3.md) for major changes
 
+## Version 2.3.7 2025-12-12
+
+- Compatibility with PHP 8.5.
+- Update license year to 2025.
+- Improve code readability.
+
+Development changes:
+
+- Add PHP 8.5 to test matrix.
+- Upgrade integration to SonarQube Cloud action.
+- Run GitHub workflow job `php-cs-fixer` using PHP 8.4.
+- Upgrade development tools.
+
 ## Version 2.3.6 2025-06-22
 
 - Compatibility with PHP 8.4.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - See [Version 3](VERSION_3.md) for major changes
 
-# Version 2.3.6 2025-06-22
+## Version 2.3.6 2025-06-22
 
 - Compatibility with PHP 8.4.
 - Update license year to 2025.
@@ -16,7 +16,7 @@ Development changes:
 - Remove Scrutinizer-CI. Thanks!
 - Upgrade development tools.
 
-# Version 2.3.5 2024-04-29
+## Version 2.3.5 2024-04-29
 
 - Allow to receive PHP Enums as value to quote.
   - For regular enums (`UnitEnum`) is parsed as the enum name.
@@ -32,7 +32,7 @@ Development changes:
   - Remove `PHP_CS_FIXER_IGNORE_ENV` when running `php-cs-fixer`.
 - Update development tools.
 
-# Version 2.3.4 2023-02-15
+## Version 2.3.4 2023-02-15
 
 - Add `psr/log: ^3.0` as a dependency.
 - Update license year. Happy 2023!
@@ -47,7 +47,7 @@ Development changes:
   - Use `GITHUB_OUTPUT` instead of `set-output`.
   - Use `sudo-bot/action-scrutinizer` action instead of install package `scrutinizer/ocular`.
 
-# Version 2.3.3 2022-08-15
+## Version 2.3.3 2022-08-15
 
 - Add compatibility with `psr/log` version 2.0.
 
@@ -57,13 +57,13 @@ Development changes:
   - Remove unused file `test/.env.travis`.
   - Review GitHub Workflow `build.yml`.
 
-# Version 2.3.2 2022-05-05
+## Version 2.3.2 2022-05-05
 
 - Improve typing on `Recordset` and `RecordsetIterator`.
 - Improve comparison to check for empty arrays, avoid `count`.
 - Refactor and improve logic for `Result::getFields()`.
 
-# Version 2.3.1 2022-04-04
+## Version 2.3.1 2022-04-04
 
 - Fix bug when escaping chars on method `Mssql\DBAL::sqlLike()` and `Sqlsrv\DBAL::sqlLike()`.
 - Update license year to 2022. Happy new year on April.
@@ -71,7 +71,7 @@ Development changes:
 - Upgrade development tools and issues found.
 
 
-# Version 2.3.0 2021-06-14
+## Version 2.3.0 2021-06-14
 
 Notice: If you are just using this library then it does not introduce any breaking change.
 If you are hacking or extending the objects of this library then this can be a backwards incompatible change.  
@@ -96,21 +96,21 @@ If you are hacking or extending the objects of this library then this can be a b
 - Upgrade to PHPUnit 9
 
 
-# Version (no new release) 2019-08-05
+## Version (no new release) 2019-08-05
 
 - Not released since it did not change but build & travis
 - Travis: use Ubuntu Xenial, move to Ubuntu Bionic once PHP 7.0 is deprecated
 - Allow phpstan version ^0.11.0
 
 
-# Version 2.2.1 2019-01-30
+## Version 2.2.1 2019-01-30
 
 - Development: Upgrade vlucas/phpdotenv from ^2.4 to ^3.3
 - Travis: Add support for PHP 7.3 on build matrix
 - Documents: Plans for next major release (version 3)
 
 
-# Version 2.2.0 2018-10-19
+## Version 2.2.0 2018-10-19
 
 - Fix parameter name on DBAL::sqlFieldEscape from $tableName to $fieldName
 - Add DBAL::sqlIsNotNull as a negative to DBAL::sqlIsNull
@@ -120,13 +120,13 @@ If you are hacking or extending the objects of this library then this can be a b
 - Move test from driver specification to DbalCommonSqlTrait on testSqlIsNull & testSqlIfNull
 - Add DBAL::sqlBetweenQuote
 
-# Version 2.1.3 2018-10-05
+## Version 2.1.3 2018-10-05
 
 - Fix bug when comparing if values had changed when comparing two strings in a recordset
   it have issues when updating values like "1" to "01". To fix it uses strict comparison when
   original value and current value are strings.
 
-# Version 2.1.2 2018-08-28
+## Version 2.1.2 2018-08-28
 
 - Improve `DBAL` docblocks
 - Add `DBAL::createQueryException` to create a new `QueryException` with DBAL::getLastMessage() or `Database error`
@@ -136,19 +136,19 @@ If you are hacking or extending the objects of this library then this can be a b
     - phpstan-shim compatible with PHP version 7.0 and 7.3
 - Fix `phpunit.xml.dist` removing `syntaxCheck` attribute and add `testsuite@name` attribute
 
-# Version 2.1.1 2018-08-01
+## Version 2.1.1 2018-08-01
 
 - `DBAL\Exceptions\QueryException` does not exposes the query in the exception message,
   if you need the query check the `getQuery()` method.
 
-# Version 2.1.0 2018-08-01
+## Version 2.1.0 2018-08-01
 
 - Add strict methods to `DBAL` as the first attempt to remove *returning false* practice
     - `DBAL::createRecordset(...): Recordset`
     - `DBAL::createPager(...): Pager`
 - Introduce `DBAL\Exceptions\QueryException` and is used when `createRecordset` or `createPager` found an error.
 
-# Version 2.0.2 2018-08-01
+## Version 2.0.2 2018-08-01
 
 - Sqlsrv\DBAL::queryDriver allow to aks only for affected rows
   When ask for affected rows it executes instead of prepare statement and execute,  performance increased!
@@ -159,7 +159,7 @@ If you are hacking or extending the objects of this library then this can be a b
     - Test behavior of NOCOUNT setting into MS Sql Server drivers
 
 
-# Version 2.0.1 2018-07-29
+## Version 2.0.1 2018-07-29
 
 - Add `connect-timeout` option to `Sqlsrv` driver
 - Fix issue when test suit end with segfault because the pdo statement in `Sqlsrv\Result` was not really destructed
@@ -168,7 +168,7 @@ If you are hacking or extending the objects of this library then this can be a b
 - Composer: rename scripts names (prefix with "dev:" and add descriptions)
 
 
-# version 2.0.0 2018-07-27
+## version 2.0.0 2018-07-27
 
 - Set minimal php version to PHP 7.0
 - Add type declarations to arguments and returns
@@ -190,7 +190,7 @@ If you are hacking or extending the objects of this library then this can be a b
 - Replace parallel-lint with phplint
 - readme: fix badges and coverage link
 
-# version 1.7.1 2018-04-20
+## version 1.7.1 2018-04-20
 - Remove duplicated verification for creating the PDO object in `\EngineWorks\DBAL\Mssql\DBAL::connect()`
 - Initialize `$vars` array in `\EngineWorks\DBAL\Mssql\DBAL::getPDOConnectionString`
 - Move logic to parse a number `DBAL::sqlQuote` to `EngineWorks\DBAL\Internal\NumericParser`
@@ -200,53 +200,53 @@ If you are hacking or extending the objects of this library then this can be a b
 - Test populate database inside a transaction (run faster)
 - Fix some simple phpstan issues
 
-# version 1.7.0 2018-01-23
+## version 1.7.0 2018-01-23
 - Add feature to prevent final (higher) commit by `DBAL::transPreventCommit()`.
 - Add new setting for mssql `freetds-version` that defaults to `7.0` it was hardcoded before.
 - (DEV) Create BaseTestCase that includes `checkPhpUnitVersion`.
   It will mark the test as incomplete if the php unit version is lower than required.
   I'm not using annotation `@requires` because it does not work with composite traits.
 
-# version 1.6.9 2018-01-10
+## version 1.6.9 2018-01-10
 - `Mysqli\DBAL::queryResult` now will warn if the query does not perform a result 
 - Fix issues discovered by scrutinizer
 - Testing locally using mssql server has been improved by not creating the database but using `tempdb`
 
-# version 1.6.8 2018-01-10
+## version 1.6.8 2018-01-10
 - Run phpstan and fix all errors in folder sources, fix possible bugs
 - Change a test for different messages on sqlite
 - Dependences: Use version numbers instead of @stable
 - Travis: Add PHP 7.1
 - Scrutinizer: Update config file to recommended content
 
-# version 1.6.7 2017-06-28
+## version 1.6.7 2017-06-28
 - Fix bug where a boolean must be cast as an integer and true does not return 1
 
-# version 1.6.6 2017-06-26
+## version 1.6.6 2017-06-26
 - Override docblock Result::getIterator() extended from \IteratorAggregate to explicity return an \Iterator object
 - Override docblock count extended from \Countable for coherence
 
-# version 1.6.5 2017-06-26
+## version 1.6.5 2017-06-26
 - Fix typo in docblock, class name is ResultIterator
 - Fix docblock ResultImplementsIterator::getIterator() : \Iterator
 - Improve testing fail message on connect at createDatabase
 - Remove development dependence on scrutinizer/ocular, only install on travis
 
-# version 1.6.4 2017-05-04
+## version 1.6.4 2017-05-04
 - Trigger an E_USER_NOTICE when rollback or commit without a transaction
 - Create TransactionsWithExceptionsTestTrait to probe previous behavior,
   the testers cannot test exceptions since all the execution runs as only one test. 
 
-# version 1.6.3 2017-03-31
+## version 1.6.3 2017-03-31
 - Remove autocommit disabled. If it is disabled dbal will not store data unless is inside a transaction.
 
-# version 1.6.2 2017-03-23
+## version 1.6.2 2017-03-23
 - Minor fixes mostly on dockblocks by Scrutinizer recommendations
 - Add validations before using Recordset::originalValues
 - Add additional test for nested transactions with begin-begin-begin-commit-rollback-commit
 - Add information to run test mssql using docker in CONTRIBUTING.md
 
-# version 1.6.1 2017-03-22
+## version 1.6.1 2017-03-22
 - Mysqli set autocommit to false
 - Support for nested transactions using savepoints
 - Internal API change due transactions refactory
@@ -255,14 +255,14 @@ If you are hacking or extending the objects of this library then this can be a b
 - Fix several docblocks
 - Implement overrideTypes on mssql and mysqli
 
-# version 1.5.2 2017-03-01
+## version 1.5.2 2017-03-01
 - Remove TODO comment
 - Continuous Integration
     - add the missing .scrutinizer.yml file
 - Documentation
     - where were the badges again?
 
-# version 1.5.1 2017-02-28
+## version 1.5.1 2017-02-28
 - Follow scrutinizer recommendations like change logical operators and avoid error suppressing when not necesary
 - Documentation:
     - add keywords to composer.json
@@ -271,7 +271,7 @@ If you are hacking or extending the objects of this library then this can be a b
     - document known problems in todo 
 - Remove coveralls
 
-# version 1.5.0 2017-02-24
+## version 1.5.0 2017-02-24
 - Add `$overrideTypes` parameter for `DBAL::queryResult` and `DBAL::queryRecordset` methods.
   The driver Sqlite does not recognize properly the commontypes of fields
 - Deprecate `DBAL::query` method
@@ -280,7 +280,7 @@ If you are hacking or extending the objects of this library then this can be a b
 - Do not build using hhvm, include php 7.1, add mysql
 - Add compatibility on php 7.1 by fixing contructor on `EngineWorks\DBAL::Settings`
 
-# version 1.4.1 2017-02-23
+## version 1.4.1 2017-02-23
 - There were some errors using the recordset on weird table and field names, this version make the following changes:
     - `sqlField(a, b) => a as "b"`: New method, only escape the alias
     - `sqlFieldEscape(a, b) => "a" as "b"`: New method, escape both, the name and the alias
@@ -288,10 +288,10 @@ If you are hacking or extending the objects of this library then this can be a b
     - `sqlTableEscape(a, b) => "a" as "b"`: Changed from protected to public
 - Change Recordset to use these methods when building the sql sentences.
 
-# version 1.3.1 2017-01-31
+## version 1.3.1 2017-01-31
 - Fix bug when sqlQuote receives a stringable object, but it does not take value to parse it as int or float
 
-# version 1.3.0  2016-11-14
+## version 1.3.0  2016-11-14
 - Add Mssql driver
 - Allow pass entity and primary keys to Recordset
 - Sqlite uses fetch behavior to reset the query
@@ -299,20 +299,20 @@ If you are hacking or extending the objects of this library then this can be a b
 - Add Travis-CI support
 - Improve documentation
 
-# version 1.2.3 2016-09-01
+## version 1.2.3 2016-09-01
 - Rename project to eclipxe/engineworks-dbal
 - Move from GitLab to GitHub
 - Changes on README
 - Introduce CoC, Contributing, TODO, LICENSE
 
-# version 1.2.2 2016-08-31
+## version 1.2.2 2016-08-31
 - Small fix on docblock of DBAL::sqlConcatenate variadic method
 - Small fix must not use numRows but resultCount()
 - Small fix inpections and warnings reported by PhpStorm
 - Rename ruleset.xml to phpcs.xml
 - Increase coverage on Sqlite\Result
 
-# version 1.2.1 2016-08-09
+## version 1.2.1 2016-08-09
 
 - Implement generic Iterators for Result and Recordset
 - Result and Recordset now implements IteratorAggregate and Countable interfaces
@@ -320,25 +320,25 @@ If you are hacking or extending the objects of this library then this can be a b
 - Test Sqlite/Result
 - Improve code style
 
-# version 1.1.3 2016-07-31
+## version 1.1.3 2016-07-31
 
 - Fix Pager with no query for count
 - Add test for pager
 - Add a sqlite database for testing
 - Improve coding standards
 
-# version 1.1.2 2016-07-25
+## version 1.1.2 2016-07-25
 
 - Move sqlLimit to a trait
 - Fix docblock on DBAL::queryRecordset
 
-# version 1.1.1 2016-06-16
+## version 1.1.1 2016-06-16
 
 - Fix bug in sdqlQuoteParseNumbers when `LC_NUMERIC` is `C`
 - Add support for PHP CS Fixer and .php_cs file
 - On tests ArrayLogger uses AbstractLogger
 
-# version 1.1.0 2016-06-09
+## version 1.1.0 2016-06-09
 
 - Create CommonTypes interface with common types constants
 - Move some methods to Traits
@@ -349,6 +349,6 @@ If you are hacking or extending the objects of this library then this can be a b
 - Code style improvements
 - Docblocks improvements
 
-# version 1.0.0 2016-06-08
+## version 1.0.0 2016-06-08
 
 - Put this code as a library

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2013 - 2025 Carlos C Soto
+Copyright (c) 2013 - 2026 Carlos C Soto
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/VERSION_3.md
+++ b/VERSION_3.md
@@ -2,9 +2,8 @@
 
 This version will introduce this fundamental changes:
 
-- [] Remove `Mssql` driver, now it only uses `Sqlsrv` to connect to MS SQL Server
-- [] Change minimal version to PHP 8.0
-- [] Parameter to negate `DBAL::sqlIsNull` will be deprecated
-- [] Parameter to negate `DBAL::sqlIn` will be deprecated
-- [] Add return types `void` and nullable `?` when possible
-- [] Change builds to use `phive`
+- [] Remove `Mssql` driver, now it only uses `Sqlsrv` to connect to MS SQL Server.
+- [] Change minimal version to latest PHP supported version.
+- [] Parameter to negate `DBAL::sqlIsNull` will be deprecated.
+- [] Parameter to negate `DBAL::sqlIn` will be deprecated.
+- [] Add return types `void` and nullable `?` when possible.

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -19,7 +19,6 @@
     <rule ref="Generic.CodeAnalysis.UnnecessaryFinalModifier"/>
     <rule ref="Generic.CodeAnalysis.UselessOverridingMethod"/>
     <rule ref="Generic.Formatting.SpaceAfterNot"/>
-    <rule ref="Generic.Functions.CallTimePassByReference"/>
     <rule ref="Generic.NamingConventions.ConstructorName"/>
     <rule ref="Generic.PHP.DeprecatedFunctions"/>
     <rule ref="Squiz.PHP.DisallowSizeFunctionsInLoops"/>

--- a/src/Abstracts/BaseDBAL.php
+++ b/src/Abstracts/BaseDBAL.php
@@ -217,7 +217,7 @@ abstract class BaseDBAL implements DBAL
             return $this->sqlQuoteParseNumber($variable, false);
         }
         if (CommonTypes::TBOOL === $commonType) {
-            return ($variable) ? '1' : '0';
+            return $variable ? '1' : '0';
         }
         if (CommonTypes::TDATE === $commonType) {
             return "'" . date('Y-m-d', (int) $variable) . "'";

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -45,15 +45,11 @@ class Factory
         if (! class_exists($classname)) {
             throw new LogicException("Class $classname does not exists");
         }
-        if ('' !== $extends) {
-            if (! in_array($extends, class_parents($classname) ?: [])) {
-                throw new LogicException("Class $classname does not extends $extends");
-            }
+        if ('' !== $extends && ! in_array($extends, class_parents($classname) ?: [])) {
+            throw new LogicException("Class $classname does not extends $extends");
         }
-        if ('' !== $implements) {
-            if (! in_array($implements, class_implements($classname) ?: [])) {
-                throw new LogicException("Class $classname does not implements $implements");
-            }
+        if ('' !== $implements && ! in_array($implements, class_implements($classname) ?: [])) {
+            throw new LogicException("Class $classname does not implements $implements");
         }
         return $classname;
     }

--- a/src/Internal/ConvertObjectToStringMethod.php
+++ b/src/Internal/ConvertObjectToStringMethod.php
@@ -17,10 +17,9 @@ trait ConvertObjectToStringMethod
      */
     private static function convertObjectToString(object $variable): string
     {
-        if (PHP_VERSION_ID > 80100) { // PHP 8.1
-            if ($variable instanceof UnitEnum) { // BackedEnum implements UnitEnum
-                return ($variable instanceof BackedEnum) ? strval($variable->value) : $variable->name;
-            }
+        // PHP 8.1 && BackedEnum implements UnitEnum
+        if (PHP_VERSION_ID > 80100 && $variable instanceof UnitEnum) {
+            return ($variable instanceof BackedEnum) ? strval($variable->value) : $variable->name;
         }
         if (class_exists(Stringable::class) && $variable instanceof Stringable) {
             return strval($variable);

--- a/src/Mssql/DBAL.php
+++ b/src/Mssql/DBAL.php
@@ -99,7 +99,7 @@ class DBAL extends BaseDBAL
 
     public function isConnected(): bool
     {
-        return ($this->pdo instanceof PDO);
+        return $this->pdo instanceof PDO;
     }
 
     public function lastInsertedID(): int

--- a/src/Mssql/Result.php
+++ b/src/Mssql/Result.php
@@ -134,6 +134,6 @@ class Result implements ResultInterface
         if ($this->resultCount() <= 0) {
             return false;
         }
-        return (false !== $this->stmt->execute());
+        return false !== $this->stmt->execute();
     }
 }

--- a/src/Mysqli/DBAL.php
+++ b/src/Mysqli/DBAL.php
@@ -94,7 +94,7 @@ class DBAL extends BaseDBAL
 
     public function isConnected(): bool
     {
-        return ($this->mysqli instanceof mysqli);
+        return $this->mysqli instanceof mysqli;
     }
 
     public function lastInsertedID(): int

--- a/src/Recordset.php
+++ b/src/Recordset.php
@@ -215,7 +215,7 @@ class Recordset implements LoggerAwareInterface, IteratorAggregate, Countable
      */
     final public function hasDBAL(): bool
     {
-        return ($this->dbal->isConnected() || $this->dbal->connect());
+        return $this->dbal->isConnected() || $this->dbal->connect();
     }
 
     /**
@@ -242,7 +242,7 @@ class Recordset implements LoggerAwareInterface, IteratorAggregate, Countable
      */
     public function canModify(): bool
     {
-        return (self::RSMODE_NOTCONNECTED !== $this->mode && '' !== $this->entity);
+        return self::RSMODE_NOTCONNECTED !== $this->mode && '' !== $this->entity;
     }
 
     /**
@@ -252,7 +252,7 @@ class Recordset implements LoggerAwareInterface, IteratorAggregate, Countable
      */
     final public function eof(): bool
     {
-        return (! is_array($this->originalValues));
+        return ! is_array($this->originalValues);
     }
 
     /**
@@ -349,10 +349,10 @@ class Recordset implements LoggerAwareInterface, IteratorAggregate, Countable
         }
         // strict comparison if types are strings
         if (is_string($original) && is_string($current)) {
-            return ($original !== $current);
+            return $original !== $current;
         }
         // simple comparison
-        return ($original != $current);
+        return $original != $current;
     }
 
     /**
@@ -504,7 +504,8 @@ class Recordset implements LoggerAwareInterface, IteratorAggregate, Countable
             $sql = $this->sqlInsert();
         }
         if (self::RSMODE_CONNECTED_EDIT == $this->mode) {
-            if ('' === $sql = $this->sqlUpdate($extraWhereClause)) {
+            $sql = $this->sqlUpdate($extraWhereClause);
+            if ('' === $sql) {
                 return 0;
             }
         }
@@ -566,7 +567,7 @@ class Recordset implements LoggerAwareInterface, IteratorAggregate, Countable
      */
     final public function moveNext(): bool
     {
-        return ($this->isOpen() && $this->fetchLoadValues());
+        return $this->isOpen() && $this->fetchLoadValues();
     }
 
     /**
@@ -575,7 +576,7 @@ class Recordset implements LoggerAwareInterface, IteratorAggregate, Countable
      */
     final public function moveFirst(): bool
     {
-        return ($this->isOpen() && $this->result()->moveFirst() && $this->fetchLoadValues());
+        return $this->isOpen() && $this->result()->moveFirst() && $this->fetchLoadValues();
     }
 
     /**

--- a/src/Sqlite/DBAL.php
+++ b/src/Sqlite/DBAL.php
@@ -68,7 +68,7 @@ class DBAL extends BaseDBAL
 
     public function isConnected(): bool
     {
-        return ($this->sqlite instanceof SQLite3);
+        return $this->sqlite instanceof SQLite3;
     }
 
     public function lastInsertedID(): int

--- a/src/Sqlsrv/DBAL.php
+++ b/src/Sqlsrv/DBAL.php
@@ -93,7 +93,7 @@ class DBAL extends BaseDBAL
 
     public function isConnected(): bool
     {
-        return ($this->pdo instanceof PDO);
+        return $this->pdo instanceof PDO;
     }
 
     public function lastInsertedID(): int

--- a/src/Sqlsrv/Result.php
+++ b/src/Sqlsrv/Result.php
@@ -164,6 +164,6 @@ class Result implements ResultInterface
         if ($this->resultCount() <= 0) {
             return false;
         }
-        return (false !== $this->stmt->execute());
+        return false !== $this->stmt->execute();
     }
 }

--- a/tests/Tests/WithDatabaseTestCase.php
+++ b/tests/Tests/WithDatabaseTestCase.php
@@ -74,7 +74,7 @@ abstract class WithDatabaseTestCase extends WithDbalTestCase
         foreach ($array as $i => $item) {
             $array[$i] = array_combine($keys, $item) ?: [];
         }
-        return $array; /** @phpstan-ignore-line return.type */
+        return $array;
     }
 
     /**


### PR DESCRIPTION
- Compatibility with PHP 8.5.
- Update license year to 2025.
- Improve code readability.

Development changes:

- Add PHP 8.4 to test matrix.
- Update `vlucas/phpdotenv` to version 5.6.2.
- Allow manual dispatch for build workflow.
- Run GitHub workflow jobs using PHP 8.4.
- Remove Scrutinizer-CI. Thanks!
- Upgrade development tools.
